### PR TITLE
Bold channel names on "new" not "unread"

### DIFF
--- a/src/client/channels.tsx
+++ b/src/client/channels.tsx
@@ -21,7 +21,8 @@ export function ChannelButton({
     { channel: option },
     { partialMatch: true },
   );
-  const hasUnread = !!summary?.unread;
+  // TODO: remove "as any" once SDK 1.3.0 ships with updated types.
+  const hasUnread = !!(summary as any)?.new;
 
   return (
     <ChannelButtonStyled


### PR DESCRIPTION
Fixes E-2855

Test Plan:
Look at all messages in #cordless, I have seen all toplevel messages but have
some messages in a subthread which are unread -- but the channel name is now
unbolded. Another channel goes from bold to unbold once reading all toplevel
messages.
