### PR TITLE
Improve browser notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.2.0",
-        "@cord-sdk/server": "^1.2.0",
+        "@cord-sdk/react": "^1.3.0",
+        "@cord-sdk/server": "^1.3.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
         "dotenv": "^16.3.1",
@@ -25,8 +25,8 @@
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
-        "@cord-sdk/api-types": "^1.2.0",
-        "@cord-sdk/types": "^1.1.0",
+        "@cord-sdk/api-types": "^1.3.0",
+        "@cord-sdk/types": "^1.3.0",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/react": "^18.2.16",
@@ -2066,26 +2066,26 @@
       }
     },
     "node_modules/@cord-sdk/api-types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.2.0.tgz",
-      "integrity": "sha512-jgicGCpsivV/DyH82o2v1RnQYFZuCC5AJIdGCpPil0/Kf92iN6DV9jxzAXOOMBomSAVsqoArP4rd6I33ZYU7Lg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.3.0.tgz",
+      "integrity": "sha512-0eZAsZm8yuYow1pThQkC20nN8zYbVuA0EK20lXHpkUVuwofmo653/5MR8zJfBNcLR+Xc/5N9q4TrNBmJ/93qhQ==",
       "dev": true
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.2.0.tgz",
-      "integrity": "sha512-xyPuOIckVbgoDw3nLpoae9h4s0eUxhQWnX+SPoGG8eUh6WCIwqhQq19qwmiwakA6JMgrmc2v077o4BiSMqYbYg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.3.0.tgz",
+      "integrity": "sha512-EQqjyZ/8iN37249/OeSclZvk92AoVM+dKUCiEiR2R92Dul/uYX8s25YC7ABcjDRmhVtWrq5aQQzG5fhOQN8WtA==",
       "dependencies": {
-        "@cord-sdk/types": "1.2.0"
+        "@cord-sdk/types": "1.3.0"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.2.0.tgz",
-      "integrity": "sha512-XnU/QHsHKeJoyzUXQQom8oIlUI4ng9gKNsvoILBLxEN8En1rkKgupd606a/q0ke1KSo9qMRZ+ADgvK6D/ArCpg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.3.0.tgz",
+      "integrity": "sha512-E4RTfU1zdKY+VpQoacNoazgLYqGXb91ZjXwQWYq9dEgagFc5P0YRrVl6M2jKcovaf/zvVPoTuNEmSjs7eFWSjQ==",
       "dependencies": {
-        "@cord-sdk/components": "1.2.0",
-        "@cord-sdk/types": "1.2.0",
+        "@cord-sdk/components": "1.3.0",
+        "@cord-sdk/types": "1.3.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -2093,17 +2093,17 @@
       }
     },
     "node_modules/@cord-sdk/server": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.2.0.tgz",
-      "integrity": "sha512-g3KzRchEElAtLg19hYMV0heimuqziovCogYrEaII5r74p9BI3R2DgRZfAJ09zkHD22CSdr8mxm6ryoMKDDQBdg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.3.0.tgz",
+      "integrity": "sha512-3ku9E0trNmXyIey8lESFPX0VjjgZQxH0/qYdiH2au/lRpE1jluFKS4mUt0Ekd4zfS594Wp/irvrHoxEWuJXT+A==",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-71ESiLPtdx7phLps4HFJKMB+7jyAn5ZPv+IUlfwq0qRXINLHOXc3pSKbnVIZ0RNhoWOHsCYzjdig8MXdw86m1w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.3.0.tgz",
+      "integrity": "sha512-pa5DOLhq6ohn4a6tiyCnDp5v4dgcPzFUjpjACiGaznqG/aKJ/9JSCY8skp4EAWJqpQLByI+LrGCBe8E/guke+w=="
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.2.0",
-    "@cord-sdk/server": "^1.2.0",
+    "@cord-sdk/react": "^1.3.0",
+    "@cord-sdk/server": "^1.3.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",
     "dotenv": "^16.3.1",
@@ -33,8 +33,8 @@
     "styled-components": "^6.0.5"
   },
   "devDependencies": {
-    "@cord-sdk/api-types": "^1.2.0",
-    "@cord-sdk/types": "^1.1.0",
+    "@cord-sdk/api-types": "^1.3.0",
+    "@cord-sdk/types": "^1.3.0",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/react": "^18.2.16",

--- a/src/client/BrowserNotificationBridge.tsx
+++ b/src/client/BrowserNotificationBridge.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import { notification } from '@cord-sdk/react';
-import type { NotificationVariables } from '@cord-sdk/types';
+import type { CoreNotificationData } from '@cord-sdk/types';
+import { useNavigate } from 'react-router-dom';
 import { showNotification } from 'src/client/notifications';
 
 export function BrowserNotificationBridge() {
+  const navigate = useNavigate();
   const { notifications } = notification.useData();
-  const newestNotif = notifications[0] as NotificationVariables | undefined;
+
+  const newestNotif = notifications[0] as CoreNotificationData | undefined;
   const prevNewestNotifIDRef = React.useRef<string | undefined>(undefined);
 
   React.useEffect(() => {
@@ -14,7 +17,7 @@ export function BrowserNotificationBridge() {
       prevNewestNotifIDRef.current &&
       newestNotif.id !== prevNewestNotifIDRef.current
     ) {
-      showNotification(newestNotif);
+      void showNotification(newestNotif, navigate);
     }
 
     prevNewestNotifIDRef.current = newestNotif?.id;

--- a/src/client/MoreActionsButton.tsx
+++ b/src/client/MoreActionsButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tooltip } from 'react-tooltip';
 import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import { styled, css } from 'styled-components';
-import type { MessageData, ThreadSummary } from '@cord-sdk/types';
+import type { CoreMessageData, ThreadSummary } from '@cord-sdk/types';
 import { Colors } from 'src/client/Colors';
 import {
   OPTIONS_ICON_HEIGHT,
@@ -19,7 +19,7 @@ export function MoreActionsButton({
   setShowOptionsDialog,
 }: {
   thread: ThreadSummary;
-  message?: MessageData;
+  message?: CoreMessageData;
   showOptionsDialog: boolean;
   setShowOptionsDialog: (state: boolean) => void;
 }) {

--- a/src/client/Options.tsx
+++ b/src/client/Options.tsx
@@ -1,7 +1,7 @@
 import { styled, css } from 'styled-components';
 import { Reactions } from '@cord-sdk/react';
 import { ChatBubbleOvalLeftEllipsisIcon } from '@heroicons/react/24/outline';
-import type { MessageData, ThreadSummary } from '@cord-sdk/types';
+import type { CoreMessageData, ThreadSummary } from '@cord-sdk/types';
 import React, { useCallback, useState } from 'react';
 import { Tooltip } from 'react-tooltip';
 import { Colors } from 'src/client/Colors';
@@ -14,7 +14,7 @@ interface OptionsProps {
   thread: ThreadSummary;
   hovered: boolean;
   onOpenThread?: (threadID: string) => void;
-  message?: MessageData;
+  message?: CoreMessageData;
 }
 
 export function Options({

--- a/src/client/ThreadDetails.tsx
+++ b/src/client/ThreadDetails.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { styled } from 'styled-components';
 import { thread } from '@cord-sdk/react/';
 import { XMarkIcon } from '@heroicons/react/20/solid';
-import type { MessageData, ThreadSummary } from '@cord-sdk/types';
+import type { CoreMessageData, ThreadSummary } from '@cord-sdk/types';
 import { PageHeader } from 'src/client/PageHeader';
 import { Colors } from 'src/client/Colors';
 import { StyledComposer, StyledMessage } from 'src/client/StyledCord';
@@ -13,7 +13,7 @@ import { TypingIndicator } from 'src/client/TypingIndicator';
 import { Options } from 'src/client/Options';
 
 interface MessageProps {
-  message: MessageData;
+  message: CoreMessageData;
   thread: ThreadSummary;
 }
 

--- a/src/client/ThreadsList.tsx
+++ b/src/client/ThreadsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { styled } from 'styled-components';
-import type { ThreadVariables } from '@cord-sdk/api-types';
+import type { CoreThreadData } from '@cord-sdk/types';
 import { useAPIFetch } from 'src/client/hooks/useAPIFetch';
 import { ChannelIcon } from 'src/client/channels';
 import { StyledThread } from 'src/client/StyledCord';
@@ -9,7 +9,7 @@ import { TypingIndicator } from 'src/client/TypingIndicator';
 
 export function ThreadsList({ cordUserID }: { cordUserID?: string }) {
   const [myThreads, setMyThreads] = React.useState<
-    ThreadVariables[] | undefined
+    CoreThreadData[] | undefined
   >();
   const allThreads = useAPIFetch<any[]>('/threads');
   React.useEffect(() => {

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -122,5 +122,5 @@ const Topbar = styled(TopbarDefault)({
 
 const ThreadDetails = styled(ThreadDetailsDefault)`
   grid-area: thread;
-  z-index: 1
+  z-index: 1;
 `;

--- a/src/client/channels.tsx
+++ b/src/client/channels.tsx
@@ -20,8 +20,7 @@ export function ChannelButton({
     { channel: option },
     { partialMatch: true },
   );
-  // TODO: remove "as any" once SDK 1.3.0 ships with updated types.
-  const hasUnread = !!(summary as any)?.new;
+  const hasUnread = !!summary?.new;
 
   return (
     <ChannelButtonStyled

--- a/src/client/notifications.ts
+++ b/src/client/notifications.ts
@@ -1,4 +1,4 @@
-import type { NotificationVariables } from '@cord-sdk/types';
+import type { CoreNotificationData } from '@cord-sdk/types';
 
 export function getBrowserNotificationPermission(): NotificationPermission {
   if (!('Notification' in window)) {
@@ -13,12 +13,12 @@ export async function requestNotificationsPermissions() {
   return Notification.requestPermission();
 }
 
-function notifHeaderString(header: NotificationVariables['header']) {
+function notifHeaderString(header: CoreNotificationData['header']) {
   let result = '';
   for (const node of header) {
-    if ('userID' in node) {
-      result += node.userID;
-    } else if ('text' in node) {
+    if (node.type === 'user') {
+      result += node.user.name;
+    } else if (node.type === 'text') {
       result += node.text;
     }
   }
@@ -26,21 +26,49 @@ function notifHeaderString(header: NotificationVariables['header']) {
   return result;
 }
 
-export function showNotification(notif: NotificationVariables) {
+function getThreadChannel(threadID: string): Promise<string> {
+  return new Promise((resolve, _reject) => {
+    const ref = window.CordSDK!.thread.observeThreadSummary(
+      threadID,
+      (summary) => {
+        window.CordSDK!.thread.unobserveThreadSummary(ref);
+        resolve(String(summary.location.channel));
+      },
+    );
+  });
+}
+
+export async function showNotification(
+  notif: CoreNotificationData,
+  navigate: (to: string) => void,
+) {
   // Check if notifications are allowed
   if (getBrowserNotificationPermission() !== 'granted') {
     return;
   }
 
+  let url: string;
+  let body: string | undefined;
+  if (notif.attachment?.type === 'message') {
+    const threadID = notif.attachment.message.threadID;
+    const channel = await getThreadChannel(threadID);
+
+    url = `/channel/${channel}/thread/${threadID}`;
+    body = notif.attachment.message.plaintext;
+  } else if (notif.attachment?.type === 'url') {
+    url = notif.attachment.url;
+  }
+
   // Create the notification
-  const notification = new Notification('Clack', {
-    body: notifHeaderString(notif.header),
-    icon: './src/client/static/clack.png', // not working?
+  const notification = new Notification(notifHeaderString(notif.header), {
+    body,
+    icon: './src/client/static/clack.png',
   });
 
   // Handle click event if desired
   notification.onclick = function () {
     window.focus(); // Bring the window into focus when the user clicks the notification
+    navigate(url);
     notification.close(); // Close the notification
   };
 }

--- a/src/server/handlers/getChannels.ts
+++ b/src/server/handlers/getChannels.ts
@@ -1,9 +1,9 @@
 import type { Request, Response } from 'express';
-import type { PlatformUserVariables } from '@cord-sdk/api-types';
+import type { ServerUserData } from '@cord-sdk/types';
 import { fetchCordRESTApi } from 'src/server/fetchCordRESTApi';
 
 export async function handleGetChannels(_: Request, res: Response) {
-  const allChannelsHolder = await fetchCordRESTApi<PlatformUserVariables>(
+  const allChannelsHolder = await fetchCordRESTApi<ServerUserData>(
     'users/all_channels_holder',
   );
 

--- a/src/server/handlers/getCordThreads.ts
+++ b/src/server/handlers/getCordThreads.ts
@@ -1,13 +1,13 @@
-import type { ThreadVariables } from '@cord-sdk/api-types';
+import type { CoreThreadData } from '@cord-sdk/types';
 import type { Request, Response } from 'express';
 import { fetchCordRESTApi } from 'src/server/fetchCordRESTApi';
 import { ORG_ID } from 'src/server/consts';
 
 export async function handleGetMyCordThreads(_: Request, res: Response) {
-  const allThreads = await fetchCordRESTApi<ThreadVariables[]>('threads');
+  const allThreads = await fetchCordRESTApi<CoreThreadData[]>('threads');
   const myThreads = allThreads.filter(
     //notes: would have been useful to filter this directly in the filters
-    (thread: ThreadVariables) => thread.organizationID === ORG_ID,
+    (thread: CoreThreadData) => thread.organizationID === ORG_ID,
   );
 
   res.send(myThreads);

--- a/src/server/handlers/getUsersInOrg.ts
+++ b/src/server/handlers/getUsersInOrg.ts
@@ -1,10 +1,10 @@
-import type { PlatformOrganizationVariables } from '@cord-sdk/api-types';
+import type { ServerOrganizationData } from '@cord-sdk/types';
 import type { Request, Response } from 'express';
 import { fetchCordRESTApi } from 'src/server/fetchCordRESTApi';
 import { ORG_ID } from 'src/server/consts';
 
 export async function handleGetCordUsers(_: Request, res: Response) {
-  const org = await fetchCordRESTApi<PlatformOrganizationVariables>(
+  const org = await fetchCordRESTApi<ServerOrganizationData>(
     `organizations/${ORG_ID}`,
   );
   res.send(org.members);


### PR DESCRIPTION
- Upgrade to SDK 1.3.0 to get type information for updated calls.
- Insert user name and not user ID. Fixes E-2844.
- Show a bit of the message in question. Fixes E-2857.
- Navigate to the thread in question upon click. Fixes E-2869.

Test Plan:
Use test user (ernest) to reply to a thread. See updated browser notifs, click
on them, get navigated to that thread.
