### PR TITLE
Add notif launcher and navigate hook [E-2888]

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { ChatBubbleOvalLeftEllipsisIcon } from '@heroicons/react/24/outline';
+import { NotificationListLauncher } from '@cord-sdk/react';
 import { Colors } from 'src/client/Colors';
 import { PageHeader } from 'src/client/PageHeader';
 import { ChannelButton, Channels } from 'src/client/channels';
@@ -17,7 +18,10 @@ export function Sidebar({ className, channelID, openPanel }: SidebarProps) {
   const navigate = useNavigate();
   return (
     <SidebarWrap className={className}>
-      <SidebarHeader>Clack</SidebarHeader>
+      <SidebarHeader>
+        <PageHeader>Clack</PageHeader>
+        <StyledNotifLauncher />
+      </SidebarHeader>
       <Panel>
         <SidebarNavButton
           option={'Threads'}
@@ -49,14 +53,19 @@ const SidebarWrap = styled.div({
   overflow: 'auto',
 });
 
-const SidebarHeader = styled(PageHeader)({
+const SidebarHeader = styled.div({
   position: 'sticky',
   top: 0,
   display: 'flex',
+  justifyContent: 'space-between',
   borderBottom: `1px solid ${Colors.purple_border}`,
   borderTop: `1px solid ${Colors.purple_border}`,
   color: 'white',
   alignItems: 'center',
+});
+
+const StyledNotifLauncher = styled(NotificationListLauncher)({
+  padding: '0 16px',
 });
 
 const SidebarNavButton = styled(ChannelButton)`

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { styled } from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
+import type { NavigateFn } from '@cord-sdk/types';
 import { Colors } from 'src/client/Colors';
 import { useAPIFetch } from 'src/client/hooks/useAPIFetch';
 import { Topbar as TopbarDefault } from 'src/client/topbar';
@@ -41,6 +42,18 @@ export function App() {
     navigate(`/channel/${channelID}/thread/${threadID}`);
   };
 
+  const onCordNavigate: NavigateFn = React.useCallback(
+    (_url, location, { threadID }) => {
+      if (!(location && 'channel' in location)) {
+        return false;
+      }
+
+      navigate(`/channel/${location.channel}/thread/${threadID}`);
+      return true;
+    },
+    [navigate],
+  );
+
   const translations = useMemo(
     () => ({
       en: { composer: { add_a_comment: `Message #${channelID}` } },
@@ -59,6 +72,7 @@ export function App() {
         enableSlack={false}
         enableTasks={false}
         enableAnnotations={false}
+        navigate={onCordNavigate}
         translations={translations}
       >
         <BrowserNotificationBridge />


### PR DESCRIPTION
This is an attempt to make Clack notifs nicely usable without spending a bunch
of time emulating Slack right now. This is totally not the right thing to do
long-term, but will so massively improve Clack usability that it's worth it.

See discussion here, in particular:
https://clack.cord.com/channel/clackless/thread/cord:d97b2f80-41ab-46e9-98ad-ce7a2f88d3d6

Test Plan: Saw notif launcher, clicked notif, went to that thread.
