### PR TITLE
Revert "feat: add blue dot and copy for unread replies"

### DIFF
--- a/src/client/Colors.tsx
+++ b/src/client/Colors.tsx
@@ -13,7 +13,6 @@ export const Colors = {
   gray_border: '#BBBABB',
   blue_selected_bg: '#E8F5FA',
   blue_selected_border: '#1D9BD1',
-  blue_unread: '#0279FF',
   blue_link: '#1264A3',
   green_active: '#2AAC76',
   green: '#117A5A',

--- a/src/client/ThreadReplies.tsx
+++ b/src/client/ThreadReplies.tsx
@@ -58,13 +58,6 @@ export function ThreadReplies({ summary, onOpenThread }: ThreadRepliesProps) {
     return null;
   }
 
-  let unreadNumber = summary.unread;
-  if (summary.firstMessage && !summary.firstMessage.seen) {
-    unreadNumber--;
-  }
-
-  const hasUnread = unreadNumber > 0;
-
   // ignoring ts here as lastMessage hasn't been deployed to types packages yet! (27/07)
   const lastReplyTime =
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -79,16 +72,7 @@ export function ThreadReplies({ summary, onOpenThread }: ThreadRepliesProps) {
     <RepliesWrapper onClick={(_e) => onOpenThread(summary.id)}>
       <Facepile users={summary.repliers} />{' '}
       <RepliesCount>
-        {hasUnread ? (
-          <UnreadReply>
-            <BlueDot />
-            <span>
-              {unreadNumber} new {unreadNumber === 1 ? 'reply' : 'replies'}
-            </span>
-          </UnreadReply>
-        ) : (
-          `${summary.total - 1} ${replyWord}`
-        )}
+        {summary.total - 1} {replyWord}
       </RepliesCount>
       <RepliesTimestamp>
         Last reply <StyledTimestamp value={lastReplyTime} />
@@ -104,17 +88,3 @@ const StyledTimestamp = styled(Timestamp)`
     font-size: 13px;
   }
 `;
-
-const UnreadReply = styled.div({
-  display: 'flex',
-  wrap: 'nowrap',
-  alignItems: 'center',
-  gap: '6px',
-});
-
-const BlueDot = styled.div({
-  borderRadius: '999px',
-  backgroundColor: Colors.blue_unread,
-  height: '8px',
-  width: '8px',
-});


### PR DESCRIPTION
Now that we have somewhat better channel-bolding and notification
behaviour, this isn't needed -- it's not what Slack does (they do not
put unread numbers in any threads).

This reverts commit 08684caaa65cd83e0632354ac927ed39c38ca8cd.

Test Plan:
Load Clack, see "X replies" but never "X new replies" under a thread.
