### PR TITLE
Use staging api endpoint

### DIFF
--- a/src/server/consts.ts
+++ b/src/server/consts.ts
@@ -2,7 +2,7 @@ export const FRONT_END_HOST =
   process.env.CLACK_ENV === 'development'
     ? 'https://local.cord.com:7307'
     : 'https://clack.cord.com';
-export const CORD_API_URL = 'https://api.cord.com/v1/';
+export const CORD_API_URL = 'https://api.staging.cord.com/v1/';
 export const CORD_APP_ID = process.env.CORD_APP_ID!;
 export const CORD_SIGNING_SECRET = process.env.CORD_SIGNING_SECRET!;
 export const ORG_ID = 'clack_all';


### PR DESCRIPTION
## Summary

I think clack should hit the staging API endpoint, to catch errors in our API before they hit production
