### PR TITLE
Fix Slack redirect

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -24,7 +24,9 @@ function useCordToken(): [string | undefined, string | undefined] {
   if (!data) {
     return [undefined, undefined];
   } else if ('redirect' in data) {
-    window.location.href = data.redirect;
+    const redirectUrl = new URL(data.redirect);
+    redirectUrl.searchParams.set('state', window.location.href);
+    window.location.href = redirectUrl.toString();
     return [undefined, undefined];
   } else {
     return [data.token, data.userID];

--- a/src/server/handlers/login.ts
+++ b/src/server/handlers/login.ts
@@ -178,7 +178,6 @@ function redirectToSlackLogin(req: Request, res: Response) {
       response_type: 'code',
       scope: ['openid', 'profile', 'email'].join(','),
       client_id: SLACK_CLIENT_ID,
-      state: req.get('Referer'), // TODO: does this need to be signed?
       team: SLACK_TEAM,
       nonce,
       redirect_uri: makeRedirectUri(req),


### PR DESCRIPTION
The redirect back from Slack suffered from the fact that the Referer header is stripped down to the origin when doing a cross-origin request (like we do to the API endpoint), so we always ended up redirecting back from the login to /, which was annoying.  Instead, have the client fill out the `state` field, since it can see the whole URL.