### PR TITLE
Upgrade cord sdk to 1.9.0 and use types for SearchResult

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.7.0",
-        "@cord-sdk/server": "^1.7.0",
+        "@cord-sdk/react": "^1.9.0",
+        "@cord-sdk/server": "^1.9.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
         "dotenv": "^16.3.1",
@@ -25,8 +25,8 @@
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
-        "@cord-sdk/api-types": "^1.7.0",
-        "@cord-sdk/types": "^1.7.0",
+        "@cord-sdk/api-types": "^1.9.0",
+        "@cord-sdk/types": "^1.9.0",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/react": "^18.2.16",
@@ -2066,45 +2066,46 @@
       }
     },
     "node_modules/@cord-sdk/api-types": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.7.0.tgz",
-      "integrity": "sha512-mi7aFVHE8byitHHkhT6joo04sijoWJbsCDi2GppGZTbJDr6qgeQAicAdpKVW6usqrYsIa1goFi5o10loWQyW1Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.9.0.tgz",
+      "integrity": "sha512-1rdlt1dDh42P8SF8Z8bH4JwAbPbU6ZNPjc+GtbJuXkzMl9OTjMpQOokHJKBlLl2ATYn+WtXSI/tZC26tC301pw==",
       "dev": true
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.7.0.tgz",
-      "integrity": "sha512-fqOG2CVl1Erb69RiJvvwqmqcmSravuFUfnjqgJ+JvWlWjP7Hb4mcYlMd5rNoNx6S5/olrYGpuIcxYuVIT8QUdg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.9.0.tgz",
+      "integrity": "sha512-mC4IdHgUGMwRak9+2ptQNbLfuOGr8Mwem8u21BCs/se0BsPBy1kug8MAYxZbMaIndCZQvXjZj/u8mV173VugmQ==",
       "dependencies": {
-        "@cord-sdk/types": "1.7.0"
+        "@cord-sdk/types": "1.9.0"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.7.0.tgz",
-      "integrity": "sha512-xlqOY1rplA4kHfmN7GDyy0hL/WuA10k7P4/83wlrMUo0D+vOXXSyMRvql0PTdsVgHtT6dLTPt1lpZLwNOyYM8w==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.9.0.tgz",
+      "integrity": "sha512-xKEFC+gL7zYFfKKhy8npKSfcDnQcPsNxfT7DOxt0qC/2vMChoF/djGrSjvYBD+jQRSN+Opt71vfwWoyM0d7uCA==",
       "dependencies": {
-        "@cord-sdk/components": "1.7.0",
-        "@cord-sdk/types": "1.7.0",
+        "@cord-sdk/components": "1.9.0",
+        "@cord-sdk/types": "1.9.0",
         "classnames": "^2.3.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "phosphor-react": "^1.4.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0"
       }
     },
     "node_modules/@cord-sdk/server": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.7.0.tgz",
-      "integrity": "sha512-KMS3De80j44pR10q/mL8EN2pK4DMRE+0359M8dh41hNT4sgWJ1NuL45/OUSGnW5R6IRGbyeIImhcHZ0S/MSKLA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.9.0.tgz",
+      "integrity": "sha512-XeGJxyNOxBkCXCyhWd4uRYKQDeY7r9fIDylFMFN4UmUpug5mcXKGDACcKvC5LkyuAIV8LTh5zw1y2Wkf+cblnA==",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.7.0.tgz",
-      "integrity": "sha512-q4IiAx9IGynewjsZVg8fcQIDwk87sXReskarhg4vFuL+3n8urlTNuKFt9HtsI5MDD4FBr1aiu+vjs6g109lbMQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.9.0.tgz",
+      "integrity": "sha512-9N6Q+PqyD7fJ6pan2E+MFr69RzSLwr6HGLA6seLeraFIVejZWD+F6sOlZpzSvKc5FfAITQnrNroYbgdpakv3nQ=="
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",
@@ -6923,6 +6924,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/phosphor-react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/phosphor-react/-/phosphor-react-1.4.1.tgz",
+      "integrity": "sha512-gO5j7U0xZrdglTAYDYPACU4xDOFBTJmptrrB/GeR+tHhCZF3nUMyGmV/0hnloKjuTrOmpSFlbfOY78H39rgjUQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -10137,42 +10149,43 @@
       }
     },
     "@cord-sdk/api-types": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.7.0.tgz",
-      "integrity": "sha512-mi7aFVHE8byitHHkhT6joo04sijoWJbsCDi2GppGZTbJDr6qgeQAicAdpKVW6usqrYsIa1goFi5o10loWQyW1Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.9.0.tgz",
+      "integrity": "sha512-1rdlt1dDh42P8SF8Z8bH4JwAbPbU6ZNPjc+GtbJuXkzMl9OTjMpQOokHJKBlLl2ATYn+WtXSI/tZC26tC301pw==",
       "dev": true
     },
     "@cord-sdk/components": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.7.0.tgz",
-      "integrity": "sha512-fqOG2CVl1Erb69RiJvvwqmqcmSravuFUfnjqgJ+JvWlWjP7Hb4mcYlMd5rNoNx6S5/olrYGpuIcxYuVIT8QUdg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.9.0.tgz",
+      "integrity": "sha512-mC4IdHgUGMwRak9+2ptQNbLfuOGr8Mwem8u21BCs/se0BsPBy1kug8MAYxZbMaIndCZQvXjZj/u8mV173VugmQ==",
       "requires": {
-        "@cord-sdk/types": "1.7.0"
+        "@cord-sdk/types": "1.9.0"
       }
     },
     "@cord-sdk/react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.7.0.tgz",
-      "integrity": "sha512-xlqOY1rplA4kHfmN7GDyy0hL/WuA10k7P4/83wlrMUo0D+vOXXSyMRvql0PTdsVgHtT6dLTPt1lpZLwNOyYM8w==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.9.0.tgz",
+      "integrity": "sha512-xKEFC+gL7zYFfKKhy8npKSfcDnQcPsNxfT7DOxt0qC/2vMChoF/djGrSjvYBD+jQRSN+Opt71vfwWoyM0d7uCA==",
       "requires": {
-        "@cord-sdk/components": "1.7.0",
-        "@cord-sdk/types": "1.7.0",
+        "@cord-sdk/components": "1.9.0",
+        "@cord-sdk/types": "1.9.0",
         "classnames": "^2.3.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "phosphor-react": "^1.4.0"
       }
     },
     "@cord-sdk/server": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.7.0.tgz",
-      "integrity": "sha512-KMS3De80j44pR10q/mL8EN2pK4DMRE+0359M8dh41hNT4sgWJ1NuL45/OUSGnW5R6IRGbyeIImhcHZ0S/MSKLA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.9.0.tgz",
+      "integrity": "sha512-XeGJxyNOxBkCXCyhWd4uRYKQDeY7r9fIDylFMFN4UmUpug5mcXKGDACcKvC5LkyuAIV8LTh5zw1y2Wkf+cblnA==",
       "requires": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "@cord-sdk/types": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.7.0.tgz",
-      "integrity": "sha512-q4IiAx9IGynewjsZVg8fcQIDwk87sXReskarhg4vFuL+3n8urlTNuKFt9HtsI5MDD4FBr1aiu+vjs6g109lbMQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.9.0.tgz",
+      "integrity": "sha512-9N6Q+PqyD7fJ6pan2E+MFr69RzSLwr6HGLA6seLeraFIVejZWD+F6sOlZpzSvKc5FfAITQnrNroYbgdpakv3nQ=="
     },
     "@emotion/unitless": {
       "version": "0.8.1",
@@ -13739,6 +13752,12 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
+    },
+    "phosphor-react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/phosphor-react/-/phosphor-react-1.4.1.tgz",
+      "integrity": "sha512-gO5j7U0xZrdglTAYDYPACU4xDOFBTJmptrrB/GeR+tHhCZF3nUMyGmV/0hnloKjuTrOmpSFlbfOY78H39rgjUQ==",
+      "requires": {}
     },
     "picocolors": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.7.0",
-    "@cord-sdk/server": "^1.7.0",
+    "@cord-sdk/react": "^1.9.0",
+    "@cord-sdk/server": "^1.9.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",
     "dotenv": "^16.3.1",
@@ -34,8 +34,8 @@
     "styled-components": "^6.0.5"
   },
   "devDependencies": {
-    "@cord-sdk/api-types": "^1.7.0",
-    "@cord-sdk/types": "^1.7.0",
+    "@cord-sdk/api-types": "^1.9.0",
+    "@cord-sdk/types": "^1.9.0",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/react": "^18.2.16",

--- a/src/client/components/SearchBar.tsx
+++ b/src/client/components/SearchBar.tsx
@@ -6,18 +6,13 @@ import React, {
   useState,
 } from 'react';
 import type { ChangeEvent } from 'react';
-import type { ClientMessageData } from '@cord-sdk/types';
+import type { SearchResultData } from '@cord-sdk/types';
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
 
 import { StyledMessage } from 'src/client/components/style/StyledCord';
 import { Overlay } from 'src/client/components/MoreActionsButton';
-
-// Until proper type is available via npm package
-type SearchResultData = ClientMessageData & {
-  location: any;
-};
 
 export function SearchBar() {
   const [showSearchPopup, setShowSearchPopup] = useState(false);
@@ -39,9 +34,6 @@ export function SearchBar() {
   useEffect(() => {
     searchTimeoutRef.current = setTimeout(() => {
       void (async () => {
-        // Not using latest SDK package so it isn't properly typed yet
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
         const data = await window.CordSDK!.thread.searchMessages({
           textToMatch: searchInput,
         });


### PR DESCRIPTION
We've released the package, so we can use the proper types now

I also had a stab at changing the use of window.cordSDK to a React hook
but failed miserably

Test Plan: Still works, no TS errors
