### PR TITLE
Extract from: for search author

### DIFF
--- a/src/client/context/UsersProvider.tsx
+++ b/src/client/context/UsersProvider.tsx
@@ -8,10 +8,6 @@ type UsersContextType = {
 
 export const UsersContext = createContext<UsersContextType>({ usersData: [] });
 
-export function isDefined<T>(value: T | null | undefined): value is T {
-  return value !== null && value !== undefined;
-}
-
 export function UsersProvider({ children }: React.PropsWithChildren) {
   const usersData = useAPIFetch<ServerUserData[]>('/usersData');
 


### PR DESCRIPTION
Add code so that you can search by message author in Search.  It will
extract a string like 'from:Terrence' or 'from:@Terrence', take that out
of the text to match, find the id of a user with a name like Terrence
and search for them.

It is not great.

Test Plan:
Type "from:Adam Slack" in search bar, see only results from Adam about
Slack.  "Slack from:Adam", `Slack from:@Adam` etc are the same
