### PR TITLE
Also add search by channel

### DIFF
--- a/src/client/context/UsersProvider.tsx
+++ b/src/client/context/UsersProvider.tsx
@@ -8,10 +8,6 @@ type UsersContextType = {
 
 export const UsersContext = createContext<UsersContextType>({ usersData: [] });
 
-export function isDefined<T>(value: T | null | undefined): value is T {
-  return value !== null && value !== undefined;
-}
-
 export function UsersProvider({ children }: React.PropsWithChildren) {
   const usersData = useAPIFetch<ServerUserData[]>('/usersData');
 


### PR DESCRIPTION
Similar to searching by message author - now you can specify the channel!

Test Plan:
Searching for 'in:general' just shows messages in #general
Searching for 'in:general from:josh' just shows messages from Josh in #general!
Searching for 'in:general from:josh test' just shows messages from Josh
in #general with a word like 'test' in them
