### PR TITLE
Turn the search pop to a scrollable container

### DIFF
--- a/src/client/components/SearchBar.tsx
+++ b/src/client/components/SearchBar.tsx
@@ -204,10 +204,12 @@ const SearchPopup = styled.div({
   display: 'flex',
   flexDirection: 'column',
   left: '200px',
-  minWidth: '65%',
+  width: '65%',
   position: 'absolute',
   top: '4px',
   boxShadow: '0px 0px 16px 0px #00000029',
+  maxHeight: '700px',
+  overflow: 'scroll',
 });
 
 const SearchContainer = styled.div({


### PR DESCRIPTION
The search pop was occupying the whole window height and more when it had lots of results. This just adds a min height and makes the pop up scrollable 🔥 

https://github.com/getcord/clack/assets/127104309/b3931dc2-73ce-4fd7-994a-9f1ac3e7dbdb


https://github.com/getcord/clack/assets/127104309/0b1b62ea-0c20-47d0-ae18-e93a41fd3cae
