### PR TITLE
Add breakpoints for better mobile support

### DIFF
--- a/src/client/components/SearchBar.tsx
+++ b/src/client/components/SearchBar.tsx
@@ -88,7 +88,7 @@ export function SearchBar() {
 
   return (
     <>
-      <SearchContainer>
+      <ResponsiveSearchContainer>
         <SearchButton
           onClick={() => {
             setShowSearchPopup(!showSearchPopup);
@@ -139,7 +139,7 @@ export function SearchBar() {
             )}
           </SearchPopup>
         )}
-      </SearchContainer>
+      </ResponsiveSearchContainer>
       <Overlay
         onClick={() => setShowSearchPopup(false)}
         $shouldShow={showSearchPopup}
@@ -263,6 +263,8 @@ const SearchPopup = styled.div({
   overflow: 'scroll',
 });
 
+// Can't add @media query to div({}) syntax, hence why
+// separate ResponsiveSearchContainer below.
 const SearchContainer = styled.div({
   flex: '2',
   marginLeft: '260px',
@@ -270,6 +272,12 @@ const SearchContainer = styled.div({
   maxWidth: '732px',
   zIndex: '1',
 });
+const ResponsiveSearchContainer = styled(SearchContainer)`
+  @media (max-width: 768px) {
+    margin: 0;
+    margin: 0 8px;
+  }
+`;
 
 const SearchButton = styled.button({
   backgroundColor: '#5C3D5E',

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -13,9 +13,15 @@ type SidebarProps = {
   className?: string;
   channelID: string;
   openPanel: string | null;
+  setShowSidebar?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-export function Sidebar({ className, channelID, openPanel }: SidebarProps) {
+export function Sidebar({
+  className,
+  channelID,
+  openPanel,
+  setShowSidebar,
+}: SidebarProps) {
   const navigate = useNavigate();
 
   // API call here so it doesn't rerun when context menu is opened
@@ -44,7 +50,10 @@ export function Sidebar({ className, channelID, openPanel }: SidebarProps) {
         </Panel>
         <Divider />
         <Channels
-          setCurrentChannel={(channel) => navigate(`/channel/${channel}`)}
+          setCurrentChannel={(channel) => {
+            navigate(`/channel/${channel}`);
+            setShowSidebar?.(false);
+          }}
           currentChannel={channelID}
           channels={channelsOptions}
         />

--- a/src/client/components/Topbar.tsx
+++ b/src/client/components/Topbar.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Avatar as DefaultAvatar, presence } from '@cord-sdk/react';
 import { styled } from 'styled-components';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ChevronLeftIcon, HashtagIcon } from '@heroicons/react/20/solid';
 import { Modal } from 'src/client/components/Modal';
 import { useUserStatus } from 'src/client/hooks/useUserStatus';
 import { SetStatusMenu } from 'src/client/components/SetStatus';
@@ -9,16 +11,23 @@ import { ActiveBadge as DefaultActiveBadge } from 'src/client/components/ActiveB
 import { SetToActiveModal } from 'src/client/components/SetToActiveModal';
 import { UserPreferencesDropdown } from 'src/client/components/UserPreferenceDropdown';
 import { SearchBar } from 'src/client/components/SearchBar';
+import { BREAKPOINTS_PX } from 'src/client/consts/consts';
 
 type ModalState = null | 'SET_STATUS' | 'PREFERENCES';
 
 export const Topbar = ({
   userID,
   className,
+  setShowSidebar,
 }: {
   userID?: string;
   className?: string;
+  setShowSidebar?: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
+  const { channelID: channelIDParam } = useParams();
+  const navigate = useNavigate();
+  const channelID = channelIDParam ?? 'general';
+
   const [isActive, setIsActive] = useUserActivity();
   const [status, updateStatus] = useUserStatus();
   const present = presence.useLocationData(
@@ -60,6 +69,12 @@ export const Topbar = ({
 
   return (
     <Container className={className}>
+      <GoBack onClick={() => navigate(`/channel/${channelID}`)}>
+        <ChevronLeftIcon width={16} height={16} />
+      </GoBack>
+      <ChannelsList onClick={() => setShowSidebar?.((prev) => !prev)}>
+        <HashtagIcon width={16} height={16} />
+      </ChannelsList>
       <SearchBar />
       <AvatarWrapper onClick={onAvatarClick}>
         {userID && <Avatar userId={userID} enableTooltip />}
@@ -105,6 +120,50 @@ export const Topbar = ({
     </Container>
   );
 };
+
+const Button = styled.button`
+  align-items: center;
+  background: none;
+  border-radius: 4px;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: none;
+  flex-shrink: 0;
+  font: inherit;
+  height: 26px;
+  justify-content: center;
+  line-height: inherit;
+  margin-left: 8px;
+  opacity: 0.8;
+  overflow: initial;
+  padding: 0;
+  text-align: initial;
+  vertical-align: initial;
+  width: 26px;
+
+  &:hover {
+    background: #5c3d5e;
+  }
+`;
+
+const GoBack = styled(Button)`
+  @media (max-width: ${BREAKPOINTS_PX.FULLSCREEN_THREADS}px) {
+    .openThread & {
+      display: flex;
+    }
+  }
+`;
+
+const ChannelsList = styled(Button)`
+  @media (max-width: ${BREAKPOINTS_PX.COLLAPSE_SIDEBAR}px) {
+    display: flex;
+
+    .openThread & {
+      display: none;
+    }
+  }
+`;
 
 const Container = styled.div({
   position: 'relative',

--- a/src/client/components/style/GlobalStyle.tsx
+++ b/src/client/components/style/GlobalStyle.tsx
@@ -20,7 +20,7 @@ export const GlobalStyle = createGlobalStyle`
   
   html,
   body {
-    height: 100vh;
+    height: 100%;
     margin: 0;
     font-family: Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI',
           Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',

--- a/src/client/consts/consts.ts
+++ b/src/client/consts/consts.ts
@@ -5,3 +5,8 @@ export const API_HOST = window.location.host.includes('local')
 export const FRONT_END_HOST = window.location.host.includes('local')
   ? 'https://local.cord.com:7307'
   : 'https://clack.cord.com';
+
+export const BREAKPOINTS_PX = {
+  FULLSCREEN_THREADS: 1200,
+  COLLAPSE_SIDEBAR: 768,
+};

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="UTF-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" >
     <link rel="icon" type="image/x-icon" href="/static/clack.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Summary:
I use clack on my phone, it'd be great if it was responsive!

Know issues: if you resize from mobile view to big view while the `openSidebar` class is applied, things will look funky, as saic class isn't removed. Refresh to fix. (or I could add a resize observer... but it felt edge-casy enough to not do that)

Test plan:
Eyes. Demo'd during hackaton.