### PR TITLE
Close search dropdown on message click

### DIFF
--- a/src/client/components/SearchBar.tsx
+++ b/src/client/components/SearchBar.tsx
@@ -59,15 +59,21 @@ export function SearchBar() {
     return () => clearTimeout(searchTimeoutRef.current);
   }, [searchInput, usersData]);
 
-  const searchResultsArray = useMemo(() => {
-    return searchResults?.map((message) => {
-      return <SingleSearchResult key={message.id} message={message} />;
-    });
-  }, [searchResults]);
-
   const close = useCallback(() => {
     setShowSearchPopup(false);
   }, []);
+
+  const searchResultsArray = useMemo(() => {
+    return searchResults?.map((message) => {
+      return (
+        <SingleSearchResult
+          key={message.id}
+          message={message}
+          closeSearch={close}
+        />
+      );
+    });
+  }, [close, searchResults]);
 
   useEffect(() => {
     document.addEventListener('keydown', (e: KeyboardEvent) => {
@@ -140,7 +146,13 @@ export function SearchBar() {
   );
 }
 
-const SingleSearchResult = ({ message }: { message: SearchResultData }) => {
+const SingleSearchResult = ({
+  message,
+  closeSearch,
+}: {
+  message: SearchResultData;
+  closeSearch: () => void;
+}) => {
   const navigate = useNavigate();
   const channelName = message.location.channel;
   const url = `/channel/${channelName}/thread/${message.threadID}`;
@@ -160,6 +172,7 @@ const SingleSearchResult = ({ message }: { message: SearchResultData }) => {
         messageId={message.id}
         onClick={() => {
           navigate(url);
+          closeSearch();
         }}
       />
     </SingleSearchResultContainer>


### PR DESCRIPTION
I think it makes sense to close the search results when you navigate
to one of the messages

Your search is still there if you reopen the bar so you won't lose anything
in that sense, if you wanted to try another link

Test Plan:
Search for something, click on a result, Clack navigates there and
closes Search
