### PR TITLE
Add min height message wrapper to reduce jank

### DIFF
--- a/src/client/components/SearchBar.tsx
+++ b/src/client/components/SearchBar.tsx
@@ -161,23 +161,31 @@ const SingleSearchResult = ({
     day: 'numeric',
     month: 'short',
   });
+
   return (
     <SingleSearchResultContainer>
       <SingleSearchResultHeader>
         # {channelName} - {date}
       </SingleSearchResultHeader>
-      <StyledMessage
-        key={message.id}
-        threadId={message.threadID}
-        messageId={message.id}
-        onClick={() => {
-          navigate(url);
-          closeSearch();
-        }}
-      />
+      <MessageContainer>
+        <StyledMessage
+          key={message.id}
+          threadId={message.threadID}
+          messageId={message.id}
+          onClick={() => {
+            navigate(url);
+            closeSearch();
+          }}
+        />
+      </MessageContainer>
     </SingleSearchResultContainer>
   );
 };
+
+// simple fix to reduce the jump on load a bit
+const MessageContainer = styled.div`
+  min-height: 50px;
+`;
 
 const SingleSearchResultContainer = styled.div`
   background: #fff;


### PR DESCRIPTION
when search results load it's currently a bit jumpy because we show
the channel header bit immediately but then the Cord Message needs to
go away and load its data... 🥲

this is a very basic way to reduce the movement on load

Test Plan: do some searches, see less jumping
