### PR TITLE
Use overflow auto instead of scroll

### DIFF
--- a/src/client/components/SearchBar.tsx
+++ b/src/client/components/SearchBar.tsx
@@ -260,7 +260,7 @@ const SearchPopup = styled.div({
   top: '4px',
   boxShadow: '0px 0px 16px 0px #00000029',
   maxHeight: '700px',
-  overflow: 'scroll',
+  overflow: 'auto',
 });
 
 const SearchContainer = styled.div({

--- a/src/client/components/UsersInChannelModal.tsx
+++ b/src/client/components/UsersInChannelModal.tsx
@@ -110,7 +110,7 @@ const Heading = styled.h2({
 
 const UsersList = styled.div({
   fontSize: '13px',
-  overflow: 'scroll',
+  overflow: 'auto',
   maxHeight: '60vh',
   borderRadius: '12px',
 });


### PR DESCRIPTION
Setting `overflow: scroll` causes the scroll bars to appear
unconditionally, even if the content isn't big enough to actually need
them. Much of the company uses macOS with a trackpad, in which case
macOS doesn't render a "hard" scroll bar gutter, so this is hard to
notice. But for the sanity of those of us who do use a hardware mouse,
we should set `overflow: auto` which displays the scroll bars only if
the content actually needs them.

Test Plan:
The search box and "users in channel" boxes no longer have spurious
scroll bars appearing for both axes. THe "users in channel" modal does
still have a vertical one, as it does need to scroll that axis.
