### PR TITLE
Pass a Channel object around instead of a channel ID

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -45,10 +45,12 @@ export function App() {
   const navigate = useNavigate();
   const location = useLocation();
   const openPanel = location.pathname.split('/')[1];
-  const channelID = openPanel === 'channel' ? channelIDParam || 'general' : '';
+  const channel = {
+    id: openPanel === 'channel' ? channelIDParam || 'general' : '',
+  };
 
   const onOpenThread = (threadID: string) => {
-    navigate(`/channel/${channelID}/thread/${threadID}`);
+    navigate(`/channel/${channel.id}/thread/${threadID}`);
   };
 
   const onCordNavigate: NavigateFn = React.useCallback(
@@ -65,16 +67,16 @@ export function App() {
 
   const translations = useMemo(
     () => ({
-      en: { composer: { add_a_comment: `Message #${channelID}` } },
+      en: { composer: { add_a_comment: `Message #${channel.id}` } },
     }),
-    [channelID],
+    [channel.id],
   );
 
   return (
     <>
       <GlobalStyle />
       <Helmet>
-        <title>#{channelID} - Clack</title>
+        <title>#{channel.id} - Clack</title>
       </Helmet>
       <CordProvider
         clientAuthToken={cordToken}
@@ -93,7 +95,7 @@ export function App() {
             >
               <Topbar userID={cordUserID} setShowSidebar={setShowSidebar} />
               <Sidebar
-                channelID={channelID}
+                channel={channel}
                 openPanel={openPanel}
                 setShowSidebar={setShowSidebar}
               />
@@ -101,8 +103,8 @@ export function App() {
                 <ResponsiveContent>
                   {openPanel === 'channel' && (
                     <Chat
-                      key={channelID}
-                      channel={channelID}
+                      key={channel.id}
+                      channel={channel}
                       onOpenThread={onOpenThread}
                     />
                   )}
@@ -113,9 +115,9 @@ export function App() {
                 </ResponsiveContent>
                 {threadID && (
                   <ThreadDetails
-                    channelID={channelID}
+                    channel={channel}
                     threadID={threadID}
-                    onClose={() => navigate(`/channel/${channelID}`)}
+                    onClose={() => navigate(`/channel/${channel.id}`)}
                   />
                 )}
               </MessageProvider>

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { styled } from 'styled-components';
 import { HashtagIcon } from '@heroicons/react/20/solid';
 import { thread } from '@cord-sdk/react';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { ChannelsRightClickMenu } from 'src/client/components/ChannelsRightClickMenu';
 import { Overlay } from 'src/client/components/MoreActionsButton';
@@ -39,12 +40,12 @@ export function ChannelButton({
 }
 
 export function Channels({
-  setCurrentChannel,
+  setCurrentChannelID,
   currentChannel,
   channels,
 }: {
-  setCurrentChannel: (channel: string) => void;
-  currentChannel: string;
+  setCurrentChannelID: (channel: string) => void;
+  currentChannel: Channel;
   channels: string[];
 }) {
   const [contextMenuPosition, setContextMenuPosition] = useState({
@@ -60,9 +61,9 @@ export function Channels({
       <ChannelsList>
         {channels.map((option, index) => (
           <ChannelButton
-            isActive={currentChannel === option}
+            isActive={currentChannel.id === option}
             key={index}
-            onClick={() => setCurrentChannel(option)}
+            onClick={() => setCurrentChannelID(option)}
             onContextMenu={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
               setContextMenuPosition({

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { styled } from 'styled-components';
 import { thread } from '@cord-sdk/react';
+import type { Channel } from 'src/client/consts/Channel';
 import { PinnedMessages } from 'src/client/components/PinnedMessages';
 import { Toolbar } from 'src/client/components/Toolbar';
 import { PushPinSvg } from 'src/client/components/svg/PushPinSVG';
@@ -12,7 +13,7 @@ import { useAPIFetch } from 'src/client/hooks/useAPIFetch';
 import { PageUsersLabel } from 'src/client/components/PageUsersLabel';
 
 interface ChatProps {
-  channel: string;
+  channel: Channel;
   onOpenThread: (threadID: string) => void;
 }
 
@@ -20,7 +21,7 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
   const usersInChannel = useAPIFetch<(string | number)[]>('/users');
 
   const { threads: pinnedThreads } = thread.useLocationData(
-    { channel },
+    { channel: channel.id },
     {
       filter: {
         metadata: {
@@ -39,7 +40,7 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
     <Wrapper>
       <ChannelDetailsBar>
         <PageHeaderWrapper>
-          <PageHeader># {channel}</PageHeader>
+          <PageHeader># {channel.id}</PageHeader>
           {usersInChannel && (
             <PageUsersLabel users={usersInChannel} channel={channel} />
           )}
@@ -71,8 +72,8 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
         onOpenThread={onOpenThread}
       />
       <StyledComposer
-        location={{ channel }}
-        threadName={`#${channel}`}
+        location={{ channel: channel.id }}
+        threadName={`#${channel.id}`}
         showExpanded
       />
     </Wrapper>

--- a/src/client/components/EmptyChannel.tsx
+++ b/src/client/components/EmptyChannel.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { styled } from 'styled-components';
+import type { Channel } from 'src/client/consts/Channel';
 
 interface EmptyChannelProps {
-  channelID: string;
+  channel: Channel;
 }
 
-export function EmptyChannel({ channelID }: EmptyChannelProps) {
+export function EmptyChannel({ channel }: EmptyChannelProps) {
   return (
     <Root>
-      <ChannelName>#{channelID}</ChannelName>
+      <ChannelName>#{channel.id}</ChannelName>
       <div>
-        This is the very beginning of the <strong>#{channelID}</strong> channel.
+        This is the very beginning of the <strong>#{channel.id}</strong>{' '}
+        channel.
       </div>
     </Root>
   );

--- a/src/client/components/PageUsersLabel.tsx
+++ b/src/client/components/PageUsersLabel.tsx
@@ -3,6 +3,7 @@ import { UserIcon } from '@heroicons/react/24/outline';
 import { Tooltip } from 'react-tooltip';
 import styled from 'styled-components';
 import { Facepile, user } from '@cord-sdk/react';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { combine } from 'src/client/utils';
 import { UsersInChannelModal } from 'src/client/components/UsersInChannelModal';
@@ -12,7 +13,7 @@ export function PageUsersLabel({
   channel,
 }: {
   users: (string | number)[];
-  channel: string;
+  channel: Channel;
 }) {
   const [showModal, setShowModal] = React.useState(false);
   // skip ernest the bot

--- a/src/client/components/PinnedMessages.tsx
+++ b/src/client/components/PinnedMessages.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { ThreadList } from '@cord-sdk/react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { Modal } from 'src/client/components/Modal';
 
 interface PinnedMessagesProps extends React.ComponentProps<typeof Modal> {
-  channel: string;
+  channel: Channel;
 }
 export function PinnedMessages({
   channel,
@@ -19,10 +20,10 @@ export function PinnedMessages({
       <Box>
         <CloseButton onClick={onClose} />
         <StyledThreadList
-          location={{ channel }}
+          location={{ channel: channel.id }}
           filter={{ metadata: { pinned: true } }}
           onThreadClick={(threadId) =>
-            navigate(`/channel/${channel}/thread/${threadId}`)
+            navigate(`/channel/${channel.id}/thread/${threadId}`)
           }
         />
       </Box>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { ChatBubbleOvalLeftEllipsisIcon } from '@heroicons/react/24/outline';
 import { NotificationListLauncher } from '@cord-sdk/react';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { PageHeader } from 'src/client/components/PageHeader';
 import { ChannelButton, Channels } from 'src/client/components/Channels';
@@ -11,14 +12,14 @@ import { useAPIFetch } from 'src/client/hooks/useAPIFetch';
 
 type SidebarProps = {
   className?: string;
-  channelID: string;
+  channel: Channel;
   openPanel: string | null;
   setShowSidebar?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export function Sidebar({
   className,
-  channelID,
+  channel,
   openPanel,
   setShowSidebar,
 }: SidebarProps) {
@@ -50,11 +51,11 @@ export function Sidebar({
         </Panel>
         <Divider />
         <Channels
-          setCurrentChannel={(channel) => {
-            navigate(`/channel/${channel}`);
+          setCurrentChannelID={(channelID) => {
+            navigate(`/channel/${channelID}`);
             setShowSidebar?.(false);
           }}
-          currentChannel={channelID}
+          currentChannel={channel}
           channels={channelsOptions}
         />
       </ScrollableContent>

--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -3,6 +3,7 @@ import { styled } from 'styled-components';
 import { thread } from '@cord-sdk/react/';
 import { XMarkIcon } from '@heroicons/react/20/solid';
 import type { CoreMessageData, ThreadSummary } from '@cord-sdk/types';
+import type { Channel } from 'src/client/consts/Channel';
 import { PageHeader } from 'src/client/components/PageHeader';
 import { Colors } from 'src/client/consts/Colors';
 import {
@@ -68,14 +69,14 @@ export type ThreadDetailsProps = {
   className?: string;
   threadID: string;
   onClose: () => void;
-  channelID: string;
+  channel: Channel;
 };
 
 export function ThreadDetails({
   className,
   threadID,
   onClose,
-  channelID,
+  channel,
 }: ThreadDetailsProps) {
   const { messages, loading, hasMore, fetchMore } =
     thread.useThreadData(threadID);
@@ -93,7 +94,7 @@ export function ThreadDetails({
     <ThreadDetailsWrapper className={className}>
       <ThreadDetailsHeader>
         <span style={{ gridArea: 'thread' }}>Thread</span>
-        <ChannelName># {channelID}</ChannelName>
+        <ChannelName># {channel.id}</ChannelName>
         <CloseButton onClick={onClose}>
           <StyledXMarkIcon />
         </CloseButton>

--- a/src/client/components/Threads.tsx
+++ b/src/client/components/Threads.tsx
@@ -3,6 +3,7 @@ import { thread } from '@cord-sdk/react';
 import { styled } from 'styled-components';
 import { ArrowDownIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import type { ThreadSummary } from '@cord-sdk/types';
+import type { Channel } from 'src/client/consts/Channel';
 import { PaginationTrigger } from 'src/client/components/PaginationTrigger';
 import { MessageListItem } from 'src/client/components/MessageListItem';
 import { EmptyChannel } from 'src/client/components/EmptyChannel';
@@ -11,7 +12,7 @@ import { Colors } from 'src/client/consts/Colors';
 import { MessageContext } from 'src/client/context/MessageContext';
 
 type ThreadsProps = {
-  channel: string;
+  channel: Channel;
   onOpenThread: (threadID: string) => void;
   onScrollUp: () => void;
   onScrollToBottom: () => void;
@@ -24,7 +25,7 @@ export function Threads({
   onScrollUp,
 }: ThreadsProps) {
   const { threads, loading, hasMore, fetchMore } = thread.useLocationData(
-    { channel },
+    { channel: channel.id },
     {
       sortDirection: 'descending',
     },
@@ -120,7 +121,7 @@ export function Threads({
           {firstMessageTimestamp && (
             <DateDivider timestamp={firstMessageTimestamp} />
           )}
-          <EmptyChannel channelID={channel} />
+          <EmptyChannel channel={channel} />
         </>
       ) : null}
       {unseenMessages.length && !isAtBottomOfThreads() ? (

--- a/src/client/components/UsersInChannelModal.tsx
+++ b/src/client/components/UsersInChannelModal.tsx
@@ -6,6 +6,7 @@ import {
   presence,
   user,
 } from '@cord-sdk/react';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { ActiveBadge } from 'src/client/components/ActiveBadge';
 import { Name } from 'src/client/components/Name';
@@ -13,7 +14,7 @@ import { XIcon } from 'src/client/components/Buttons';
 
 interface UsersInChannelModalProps {
   onClose: () => void;
-  channel: string;
+  channel: Channel;
   users: (string | number)[];
 }
 
@@ -32,7 +33,7 @@ export function UsersInChannelModal({
     <Modal>
       <Box>
         <Header>
-          <Heading># {channel}</Heading>
+          <Heading># {channel.id}</Heading>
           <CloseButton onClick={onClose}>
             <XIcon />
           </CloseButton>

--- a/src/client/consts/Channel.ts
+++ b/src/client/consts/Channel.ts
@@ -1,0 +1,3 @@
+export type Channel = {
+  id: string;
+};


### PR DESCRIPTION
Makes it easier to stick other things in here, such as an org ID
shortly.

Test Plan: Send a message to `#noise`, respond to it, seems to work.
