### PR TITLE
Channel list is a map from name to org

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -49,6 +49,9 @@ export function App() {
     id: openPanel === 'channel' ? channelIDParam || 'general' : '',
   };
 
+  const allChannelsToOrg =
+    useAPIFetch<Record<string, unknown>>('/channels') ?? {};
+
   const onOpenThread = (threadID: string) => {
     navigate(`/channel/${channel.id}/thread/${threadID}`);
   };
@@ -96,6 +99,7 @@ export function App() {
               <Topbar userID={cordUserID} setShowSidebar={setShowSidebar} />
               <Sidebar
                 channel={channel}
+                allChannels={Object.keys(allChannelsToOrg)}
                 openPanel={openPanel}
                 setShowSidebar={setShowSidebar}
               />

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -8,11 +8,11 @@ import { Colors } from 'src/client/consts/Colors';
 import { PageHeader } from 'src/client/components/PageHeader';
 import { ChannelButton, Channels } from 'src/client/components/Channels';
 import { NotificationsRequestBanner } from 'src/client/components/NotificationsRequestBanner';
-import { useAPIFetch } from 'src/client/hooks/useAPIFetch';
 
 type SidebarProps = {
   className?: string;
   channel: Channel;
+  allChannels: string[];
   openPanel: string | null;
   setShowSidebar?: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -20,13 +20,11 @@ type SidebarProps = {
 export function Sidebar({
   className,
   channel,
+  allChannels,
   openPanel,
   setShowSidebar,
 }: SidebarProps) {
   const navigate = useNavigate();
-
-  // API call here so it doesn't rerun when context menu is opened
-  const channelsOptions = useAPIFetch<string[]>('/channels') ?? [];
 
   return (
     <SidebarWrap className={className}>
@@ -56,7 +54,7 @@ export function Sidebar({
             setShowSidebar?.(false);
           }}
           currentChannel={channel}
-          channels={channelsOptions}
+          channels={allChannels}
         />
       </ScrollableContent>
       <NotificationsRequestBanner />

--- a/src/server/handlers/getChannels.ts
+++ b/src/server/handlers/getChannels.ts
@@ -1,39 +1,46 @@
 import type { Request, Response } from 'express';
 
+/**
+ * Map of channel name to the org that determines the channel's membership (or
+ * null if it should be "everyone").
+ */
+const allChannels: Record<string, string | null> = {
+  // Please keep first (most useful):
+  general: null,
+
+  // Please keep in alphabetical order (main channels):
+  'any-questions': null,
+  'clack-allcustomers': null,
+  clackless: null,
+  cordathon: null,
+  cordless: null,
+  design: null,
+  docs: null,
+  e: null,
+  ecosystem: null,
+  epicquotes: null,
+  impromptutor: null,
+  'launch-team': null,
+  'life-snaps': null,
+  marketing: null,
+  memes: null,
+  music: null,
+  notifications: null,
+  office: null,
+  p: null,
+  'pets-of-cord': null,
+  random: null,
+  sdk: null,
+  'the-cordially-book-club': null,
+  til: null,
+  website: null,
+
+  // Please keep last (testing/spamming):
+  noise: null,
+  'what-the-quack': null,
+};
+
 export function handleGetChannels(_: Request, res: Response) {
-  res.send([
-    // Please keep first (most useful):
-    'general',
-
-    // Please keep in alphabetical order (main channels):
-    'any-questions',
-    'clack-allcustomers',
-    'clackless',
-    'cordathon',
-    'cordless',
-    'design',
-    'docs',
-    'e',
-    'ecosystem',
-    'epicquotes',
-    'impromptutor',
-    'launch-team',
-    'life-snaps',
-    'marketing',
-    'memes',
-    'music',
-    'notifications',
-    'office',
-    'p',
-    'pets-of-cord',
-    'random',
-    'sdk',
-    'the-cordially-book-club',
-    'til',
-    'website',
-
-    // Please keep last (testing/spamming):
-    'noise',
-    'what-the-quack',
-  ]);
+  // TODO: do a REST API call and filter this down based on your orgs.
+  res.send(allChannels);
 }


### PR DESCRIPTION
Right now all the orgs are `null`, but will start adding more stuff in
here soon. Just want the machinery.

We'll also need this info at a high level, so move the fetch in the
client up into `App.tsx`.

Test Plan: Load Clack, still get a list of channels on the left.
