### PR TITLE
Don't .json() Cord API errors

### DIFF
--- a/src/server/fetchCordRESTApi.ts
+++ b/src/server/fetchCordRESTApi.ts
@@ -19,5 +19,13 @@ export async function fetchCordRESTApi<T>(
       'Content-Type': 'application/json',
     },
   });
-  return response.json();
+
+  if (response.ok) {
+    return response.json();
+  } else {
+    const responseText = await response.text();
+    throw new Error(
+      `Error making Cord API call: ${response.status} ${response.statusText} ${responseText}`,
+    );
+  }
 }


### PR DESCRIPTION
They aren't JSON and so it will throw.  Copied the approach I used in
Slack White labelling

Test Plan: :eyes:
