### PR TITLE
Upgrade to SDK 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.11.0",
-        "@cord-sdk/server": "^1.11.0",
+        "@cord-sdk/react": "^1.12.0",
+        "@cord-sdk/server": "^1.12.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
         "dotenv": "^16.3.1",
@@ -25,8 +25,8 @@
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
-        "@cord-sdk/api-types": "^1.11.0",
-        "@cord-sdk/types": "^1.11.0",
+        "@cord-sdk/api-types": "^1.12.0",
+        "@cord-sdk/types": "^1.12.0",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/react": "^18.2.16",
@@ -2066,27 +2066,28 @@
       }
     },
     "node_modules/@cord-sdk/api-types": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.11.0.tgz",
-      "integrity": "sha512-pC+e2GetyGZG4ss0xqobQUJND8KGE3RZ5/XF8deD1cd82N8op42TfRZWK4SYmF3UsgpfgYufhiARWrr4Zh2zxg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.12.0.tgz",
+      "integrity": "sha512-RLFFvYmUrnc9hK1e7KmpLTF9OktSZVPVSmmR/WvcSjFxPtCABmVnlHNCVtg9XAtnNENoo3PiKtD8HysQdudUFQ==",
       "dev": true
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.11.0.tgz",
-      "integrity": "sha512-R4U9Qj2GJg5dKqrlTesJj1pl7EeKDa8PNKaEDdvJAtDyvQQ3bu2TUYXQQho9RdVJEPkHPEq1zaOFRrET8iB6aA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.12.0.tgz",
+      "integrity": "sha512-mBzXvY0yTw4ec2UkecRM5TSb+s9IlP065fA6Rwgtu+QH/wM5f7PMnR4Xt0KjqV1nCebcIDS/MZVrstpQKz0bpA==",
       "dependencies": {
-        "@cord-sdk/types": "1.11.0"
+        "@cord-sdk/types": "1.12.0"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.11.0.tgz",
-      "integrity": "sha512-HXXA0p7zv4O+sQTFgLn8muvTz52mprlL3P1ZwCcD+wZFUSyHTDdBH+WgVnaVpr+We6NhqnfMiCxfesseM9raJQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.12.0.tgz",
+      "integrity": "sha512-rSKlCnSEkA9FvesES5kyeNleABrc7DI5Zi2e2Td5wDSGngVexh761Syl8j7vvy8cndx023iyiYVdNVOZLDx1BA==",
       "dependencies": {
-        "@cord-sdk/components": "1.11.0",
-        "@cord-sdk/types": "1.11.0",
+        "@cord-sdk/components": "1.12.0",
+        "@cord-sdk/types": "1.12.0",
         "classnames": "^2.3.1",
+        "fast-deep-equal": "^3.1.3",
         "phosphor-react": "^1.4.0",
         "radash": "^11.0.0"
       },
@@ -2095,17 +2096,17 @@
       }
     },
     "node_modules/@cord-sdk/server": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.11.0.tgz",
-      "integrity": "sha512-VlEqgCWmdVbourNNfU8ECqlVscgpwSAHpCrh+r5my/jiLXPwxZ3/XJ3sx4DG8RIF5g7dfFV0VHZrn9wdjbXL5w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.12.0.tgz",
+      "integrity": "sha512-9XK+P2+zKhiNpALkreQkjWBd78R6s7aM9l2cYRr8h8SqFRwyy9eDLkGwZ6xmBrqKvsYLpppWXDQlTXHEjCNrnQ==",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.11.0.tgz",
-      "integrity": "sha512-6ToFbSKY9AKayR6m5LMvjQF3MNBgKuwcf46XYfmDKOV0irnunIeJZsFDOPpIv8mpVpCkGVDb05KatnEnGaccog=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.12.0.tgz",
+      "integrity": "sha512-gNZtg+dVMtxTAbT9BG7+ejqkkVpjW5Dr4YN43ZO8CPaVNLxZDo04PrR+xJV12/yYI4YVhgxuslYg4FHmqyTgTw=="
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",
@@ -4984,8 +4985,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -10157,43 +10157,44 @@
       }
     },
     "@cord-sdk/api-types": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.11.0.tgz",
-      "integrity": "sha512-pC+e2GetyGZG4ss0xqobQUJND8KGE3RZ5/XF8deD1cd82N8op42TfRZWK4SYmF3UsgpfgYufhiARWrr4Zh2zxg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.12.0.tgz",
+      "integrity": "sha512-RLFFvYmUrnc9hK1e7KmpLTF9OktSZVPVSmmR/WvcSjFxPtCABmVnlHNCVtg9XAtnNENoo3PiKtD8HysQdudUFQ==",
       "dev": true
     },
     "@cord-sdk/components": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.11.0.tgz",
-      "integrity": "sha512-R4U9Qj2GJg5dKqrlTesJj1pl7EeKDa8PNKaEDdvJAtDyvQQ3bu2TUYXQQho9RdVJEPkHPEq1zaOFRrET8iB6aA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.12.0.tgz",
+      "integrity": "sha512-mBzXvY0yTw4ec2UkecRM5TSb+s9IlP065fA6Rwgtu+QH/wM5f7PMnR4Xt0KjqV1nCebcIDS/MZVrstpQKz0bpA==",
       "requires": {
-        "@cord-sdk/types": "1.11.0"
+        "@cord-sdk/types": "1.12.0"
       }
     },
     "@cord-sdk/react": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.11.0.tgz",
-      "integrity": "sha512-HXXA0p7zv4O+sQTFgLn8muvTz52mprlL3P1ZwCcD+wZFUSyHTDdBH+WgVnaVpr+We6NhqnfMiCxfesseM9raJQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.12.0.tgz",
+      "integrity": "sha512-rSKlCnSEkA9FvesES5kyeNleABrc7DI5Zi2e2Td5wDSGngVexh761Syl8j7vvy8cndx023iyiYVdNVOZLDx1BA==",
       "requires": {
-        "@cord-sdk/components": "1.11.0",
-        "@cord-sdk/types": "1.11.0",
+        "@cord-sdk/components": "1.12.0",
+        "@cord-sdk/types": "1.12.0",
         "classnames": "^2.3.1",
+        "fast-deep-equal": "^3.1.3",
         "phosphor-react": "^1.4.0",
         "radash": "^11.0.0"
       }
     },
     "@cord-sdk/server": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.11.0.tgz",
-      "integrity": "sha512-VlEqgCWmdVbourNNfU8ECqlVscgpwSAHpCrh+r5my/jiLXPwxZ3/XJ3sx4DG8RIF5g7dfFV0VHZrn9wdjbXL5w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.12.0.tgz",
+      "integrity": "sha512-9XK+P2+zKhiNpALkreQkjWBd78R6s7aM9l2cYRr8h8SqFRwyy9eDLkGwZ6xmBrqKvsYLpppWXDQlTXHEjCNrnQ==",
       "requires": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "@cord-sdk/types": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.11.0.tgz",
-      "integrity": "sha512-6ToFbSKY9AKayR6m5LMvjQF3MNBgKuwcf46XYfmDKOV0irnunIeJZsFDOPpIv8mpVpCkGVDb05KatnEnGaccog=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.12.0.tgz",
+      "integrity": "sha512-gNZtg+dVMtxTAbT9BG7+ejqkkVpjW5Dr4YN43ZO8CPaVNLxZDo04PrR+xJV12/yYI4YVhgxuslYg4FHmqyTgTw=="
     },
     "@emotion/unitless": {
       "version": "0.8.1",
@@ -12366,8 +12367,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.11.0",
-    "@cord-sdk/server": "^1.11.0",
+    "@cord-sdk/react": "^1.12.0",
+    "@cord-sdk/server": "^1.12.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",
     "dotenv": "^16.3.1",
@@ -34,8 +34,8 @@
     "styled-components": "^6.0.5"
   },
   "devDependencies": {
-    "@cord-sdk/api-types": "^1.11.0",
-    "@cord-sdk/types": "^1.11.0",
+    "@cord-sdk/api-types": "^1.12.0",
+    "@cord-sdk/types": "^1.12.0",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/react": "^18.2.16",

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -22,7 +22,7 @@ export function ChannelButton({
 }) {
   const summary = thread.useLocationSummary(
     { channel: option.id },
-    { partialMatch: true, filter: { organizationId: option.org } },
+    { partialMatch: true, filter: { organizationID: option.org } },
   );
   const hasUnread = !!summary?.new;
 

--- a/src/client/components/ChannelsRightClickMenu.tsx
+++ b/src/client/components/ChannelsRightClickMenu.tsx
@@ -21,7 +21,7 @@ export function ChannelsRightClickMenu({
     {
       sortBy: 'first_message_timestamp',
       sortDirection: 'descending',
-      filter: { organizationId: channel.org },
+      filter: { organizationID: channel.org },
     },
   );
 

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -27,7 +27,7 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
         metadata: {
           pinned: true,
         },
-        organizationId: channel.org,
+        organizationID: channel.org,
       },
     },
   );

--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -81,11 +81,11 @@ export function ThreadDetails({
 }: ThreadDetailsProps) {
   const { messages, loading, hasMore, fetchMore } = thread.useThreadData(
     threadID,
-    { organizationId: channel.org },
+    { organizationID: channel.org },
   );
 
   const threadSummary = thread.useThreadSummary(threadID, {
-    organizationId: channel.org,
+    organizationID: channel.org,
   });
 
   if (!threadSummary || messages.length === 0) {
@@ -135,7 +135,7 @@ export function ThreadDetails({
           ))}
         </MessageListWrapper>
         <StyledComposer autofocus threadId={threadID} showExpanded />
-        <TypingIndicator threadID={threadID} organizationId={channel.org} />
+        <TypingIndicator threadID={threadID} organizationID={channel.org} />
       </ScrollableContainer>
     </ThreadDetailsWrapper>
   );

--- a/src/client/components/Threads.tsx
+++ b/src/client/components/Threads.tsx
@@ -28,7 +28,7 @@ export function Threads({
     { channel: channel.id },
     {
       sortDirection: 'descending',
-      filter: { organizationId: channel.org },
+      filter: { organizationID: channel.org },
     },
   );
   const [unseenMessages, setUnseenMessages] = useState<ThreadSummary[]>([]);

--- a/src/client/components/ThreadsList.tsx
+++ b/src/client/components/ThreadsList.tsx
@@ -66,7 +66,7 @@ export function ThreadsList({ cordUserID }: { cordUserID?: string }) {
                   />
                   <TypingIndicator
                     threadID={thread.id}
-                    organizationId={thread.organizationID}
+                    organizationID={thread.organizationID}
                   />
                 </ThreadWrapper>
               );

--- a/src/client/components/TypingIndicator.tsx
+++ b/src/client/components/TypingIndicator.tsx
@@ -4,16 +4,16 @@ import { keyframes, styled } from 'styled-components';
 
 export function TypingIndicator({
   threadID,
-  // TODO: passing in the organizationId as a prop like this is incredibly ugly.
+  // TODO: passing in the organizationID as a prop like this is incredibly ugly.
   // This is a Cord issue, not a Clack issue -- we need to support passing
   // `null` for the org ID, since Cord should be able to "figure it out" from
   // the thread ID. We don't support that yet, but it's planned.
-  organizationId,
+  organizationID,
 }: {
   threadID: string;
-  organizationId: string | undefined;
+  organizationID: string | undefined;
 }) {
-  const summary = thread.useThreadSummary(threadID, { organizationId });
+  const summary = thread.useThreadSummary(threadID, { organizationID });
   const typingUsers = summary?.typing ?? [];
 
   return (


### PR DESCRIPTION
This version made a breaking change around `organizationId`'s spelling.
Clack is the only app in the world using it so we didn't bother with BC,
but do need to fix it now.

Test Plan: TS is happy.
