### PR TITLE
style: position status badge

### DIFF
--- a/src/client/components/Topbar.tsx
+++ b/src/client/components/Topbar.tsx
@@ -189,8 +189,6 @@ const DarkBGModal = styled(Modal)`
 const AvatarWrapper = styled.div({
   display: 'flex',
   flexDirection: 'row',
-  alignItems: 'center',
-  width: 'min-content',
   backgroundColor: 'inherit',
 });
 


### PR DESCRIPTION
I noticed the activity badge didn't seem to be in the right place. I noticed a new `classname` being passed to it from https://github.com/getcord/clack/pull/43 fixing some mobile styling issues, when I toggled it to see what it fixed I didn't notice anything - please let me know if I'm missing an edge case! 

Video showing the difference: 

https://github.com/getcord/clack/assets/62358728/e854038c-38fa-4314-ac08-e2d8f404f21d

I also added a background colour to the avatar wrapper for the activity badge to inherit 

Before: 
<img width="66" alt="image" src="https://github.com/getcord/clack/assets/62358728/60799e8b-8a23-4b4e-94e2-ac4c6d64d3a6">

After: 
<img width="40" alt="image" src="https://github.com/getcord/clack/assets/62358728/2672afd5-b66b-4cea-a8e0-5c77492c83f5">
