### PR TITLE
Client useAPIFetch should check for errors

### DIFF
--- a/src/client/hooks/useAPIFetch.ts
+++ b/src/client/hooks/useAPIFetch.ts
@@ -10,7 +10,13 @@ export function useAPIFetch<T extends object = object>(
     fetch(`${API_HOST}${path}`, {
       credentials: 'include',
     })
-      .then((resp) => resp.json())
+      .then((resp) =>
+        resp.ok
+          ? resp.json()
+          : resp.text().then((text) => {
+              throw new Error(`Response is not okay: ${text}`);
+            }),
+      )
       .then((data) => {
         setData(data);
       })


### PR DESCRIPTION
OK the failure mode here is hilarious. We saw this error:
https://getcord.slack.com/archives/C02670K69M0/p1694442946474589

An extremely strange error, which doesn't really appear in monorepo.
It makes sense when you realise that `Internal server error - check the
server logs` is what Clack is trying to use as an org name!

What it looks like happened:
1. New person started working at Cord today.
2. Signed into Clack for the first time.
3. When that happens, we rely on the first `CordSDK.init` to actually
   create their Cord user.
4. Which races against Clack's `/channels` fetching their user and list
   of orgs. In this case, `/channels` lost and we got an error back from
   Cord's REST API.
5. The Clack server detects this error and throws an exception.
6. Clack's express config catches this exception and returns a 500 with
   content `{error: 'error', message: 'Internal server error - check the
   server logs'}`.
7. Clack's frontend does *not* check for errors and happily uses this as
   the list of channels.
8. The list of channels is formatted as `{channel_name: 'org_name'}` and
   so the frontend thinks that two channels exist, `#error` and
   `#message`, and that the org to use for both is those strings
   respectively.
9. If you load up `#message` then Cord gets unhappy the org doesn't
   exist.

Steps (4) and (7) above are *both* bugs. This PR fixes (7). We should
eventually fix (4) but it will resolve itself on refresh since their
user will have been created by then so I don't feel too bad about it and
since we want to rewrite this code a bit as part of the privacy work (no
org ID in the token) (which will have to deal with this issue properly I
think).

Test Plan:
Force `/channels` to throw an error, get a `console.error` now with this
text instead of the previous hilarity.