### PR TITLE
Make x button on the unread messages pill mark messages as seen (same behavior as slack)

### DIFF
--- a/src/client/components/Threads.tsx
+++ b/src/client/components/Threads.tsx
@@ -67,6 +67,12 @@ export function Threads({
     return () => el.removeEventListener('scroll', scrollHandler);
   }, [scrollHandler, threadListRef]);
 
+  const markAsRead = useCallback(() => {
+    threads.forEach((thread) => {
+      void window.CordSDK!.thread.setSeen(thread.id, true);
+    });
+  }, [threads]);
+
   const scrollToBottom = () => {
     if (threadListRef.current) {
       threadListRef.current.scrollTop = 0;
@@ -132,7 +138,7 @@ export function Threads({
             scrollToBottom();
             setUnseenMessages([]);
           }}
-          onClose={() => setUnseenMessages([])}
+          onClose={() => markAsRead()}
         />
       ) : null}
     </Root>


### PR DESCRIPTION


Test Plan:
Ran locally, hit the x on the pill and it dismissed and marked as read the messages
Without change, it would dismiss, scroll to bottom, and then as soon as you scrolled, come back
