### PR TITLE
Fix the profile details modal

### DIFF
--- a/src/client/components/Modal.tsx
+++ b/src/client/components/Modal.tsx
@@ -39,7 +39,6 @@ export function Modal({
 
 const Container = styled.div({
   position: 'relative',
-  pointerEvents: 'auto',
   height: '100%',
   width: '100%',
 });

--- a/src/client/components/ProfileDetails.tsx
+++ b/src/client/components/ProfileDetails.tsx
@@ -11,11 +11,13 @@ export function ProfileDetails({
   className,
   onMouseEnter,
   onMouseLeave,
+  onClick,
 }: {
   userID: string;
   className?: string;
   onMouseEnter: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave: React.MouseEventHandler<HTMLDivElement>;
+  onClick: React.MouseEventHandler<HTMLDivElement>;
 }) {
   const userData = user.useUserData(userID);
   const [status] = useUserStatus(userID);
@@ -33,6 +35,7 @@ export function ProfileDetails({
       className={className}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onClick={onClick}
     >
       <Banner>
         <span>Workspace Admin</span>


### PR DESCRIPTION
Make a couple changes to the profile details popup window:

Give the modal `pointer-events: none`, which makes it so when the modal pops up it doesn't fire a mouse leave event on the avatar

Consolidate the two timeouts into one.  This is both simpler and more correct, since then a mouseLeave + mouseEnter pair of events won't result in a hide-then-show sequence of the popup.

Add a click handler that just stops propagation, otherwise if you do anything inside the popup (like try to highlight the name), it closes the popup.