### PR TITLE
fix: add pointer events to status modal

### DIFF
--- a/src/client/components/Topbar.tsx
+++ b/src/client/components/Topbar.tsx
@@ -203,6 +203,7 @@ const DarkBGModal = styled(Modal)`
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: auto;
 `;
 
 const AvatarWrapper = styled.div({


### PR DESCRIPTION
Spotted a little bug where the status modal had no pointer events! I imagine it came about with some changes to the Modal component itself

Test Plan: 

Open the modal and see if you can interact with it: 

https://github.com/getcord/clack/assets/62358728/43490a67-b0c1-4e8b-acc6-cd133a927d5f

