### PR TITLE
fix: clearing status should 'dirty' the form

### DIFF
--- a/src/client/components/SetStatus.tsx
+++ b/src/client/components/SetStatus.tsx
@@ -90,9 +90,10 @@ export function SetStatusMenu({
           }}
         />
         <CloseButton
-          onClick={() =>
-            setInput({ emojiUnified: null, emojiUrl: null, text: '' })
-          }
+          onClick={() => {
+            setInput({ emojiUnified: null, emojiUrl: null, text: '' });
+            setIsDirty(true);
+          }}
         />
       </InputBox>
       <Footer>


### PR DESCRIPTION
`save` button is disabled if the status or emoji hasn't been updated, this was being updated whenever the individual fields were changed, though not when the whole status is cleared. Now it is:

https://github.com/getcord/clack/assets/62358728/ae187b5c-3e3b-4315-a520-fcaa4b7a12cc

