### PR TITLE
Lint: turn off 'ban-ts-comment' rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,7 @@ module.exports = {
     'react/no-unescaped-entities': 'off',
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
+    "@typescript-eslint/ban-ts-comment": "off",
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -100,7 +100,6 @@ export function App() {
         enableTasks={false}
         enableAnnotations={false}
         navigate={onCordNavigate}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         translations={translations}
       >

--- a/src/client/components/ThreadReplies.tsx
+++ b/src/client/components/ThreadReplies.tsx
@@ -58,14 +58,9 @@ export function ThreadReplies({ summary, onOpenThread }: ThreadRepliesProps) {
     return null;
   }
 
-  // ignoring ts here as lastMessage hasn't been deployed to types packages yet! (27/07)
   const lastReplyTime =
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    summary.lastMessage.updatedTimestamp ??
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    summary.lastMessage.createdTimestamp;
+    summary.lastMessage?.updatedTimestamp ??
+    summary.lastMessage?.createdTimestamp;
 
   const replyWord = numReplies === 1 ? 'reply' : 'replies';
   return (

--- a/src/client/components/UserPreferenceDropdown.tsx
+++ b/src/client/components/UserPreferenceDropdown.tsx
@@ -141,7 +141,6 @@ const UpdateStatusButton = styled.button({
   },
   '&:hover svg > #mouth': {
     // unfortunately styled components doesn't like the d property :(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     d: 'path("M12 18C14.2091 18 16 16.2091 16 14H8C8 16.2091 9.79086 18 12 18Z")',
     fill: 'black',


### PR DESCRIPTION
See comments in https://github.com/getcord/clack/pull/62

Removed all instances of `eslint-disable-next-line @typescript-eslint/ban-ts-comment`:
it doesn't flag an error with `@ts-ignore` anymore.

Also remove one case of @ts-ignore where I think it is no longer relevant

Test Plan: :eyes:
