### PR TITLE
fix: add pointer events to modals

### DIFF
--- a/src/client/components/Modal.tsx
+++ b/src/client/components/Modal.tsx
@@ -39,6 +39,7 @@ export function Modal({
 
 const Container = styled.div({
   position: 'relative',
+  pointerEvents: 'auto',
   height: '100%',
   width: '100%',
 });

--- a/src/client/components/PinnedMessages.tsx
+++ b/src/client/components/PinnedMessages.tsx
@@ -4,10 +4,9 @@ import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
-import { Modal as PrimitiveModal } from 'src/client/components/Modal';
+import { Modal } from 'src/client/components/Modal';
 
-interface PinnedMessagesProps
-  extends React.ComponentProps<typeof PrimitiveModal> {
+interface PinnedMessagesProps extends React.ComponentProps<typeof Modal> {
   channel: Channel;
 }
 export function PinnedMessages({
@@ -37,10 +36,6 @@ export function PinnedMessages({
     </Modal>
   );
 }
-
-const Modal = styled(PrimitiveModal)`
-  pointer-events: auto;
-`;
 
 const Box = styled.div({
   position: 'absolute',

--- a/src/client/components/Topbar.tsx
+++ b/src/client/components/Topbar.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { ChevronLeftIcon, HashtagIcon } from '@heroicons/react/20/solid';
 import { Emoji } from 'emoji-picker-react';
 import { Colors } from 'src/client/consts/Colors';
-import { Modal as PrimitiveModal } from 'src/client/components/Modal';
+import { Modal } from 'src/client/components/Modal';
 import { useUserStatus } from 'src/client/hooks/useUserStatus';
 import { SetStatusMenu } from 'src/client/components/SetStatus';
 import { useUserActivity } from 'src/client/hooks/useUserActivity';
@@ -144,10 +144,6 @@ export const Topbar = ({
   );
 };
 
-const Modal = styled(PrimitiveModal)`
-  pointer-events: auto;
-`;
-
 const Button = styled.button`
   align-items: center;
   background: none;
@@ -202,12 +198,11 @@ const Container = styled.div({
   zIndex: 3,
 });
 
-const DarkBGModal = styled(PrimitiveModal)`
+const DarkBGModal = styled(Modal)`
   background-color: rgba(0, 0, 0, 0.3);
   display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: auto;
 `;
 
 const AvatarWrapper = styled.div({
@@ -257,7 +252,6 @@ const ActiveBadge = styled(DefaultActiveBadge)`
 `;
 
 const PreferencesDropdown = styled(UserPreferencesDropdown)`
-  pointer-events: auto;
   top: 40px;
   right: 10px;
 `;


### PR DESCRIPTION
https://github.com/getcord/clack/pull/57 had removed `pointer-events: auto` from the Modal component, I should have caught it 😬  but it broke a few of the existing instances. 

This PR adds it back in to provide the default behaviour of being able to interact with the Modal and having `onClickOutside` out of the box without having to update pointer events for each instance. 


https://github.com/getcord/clack/assets/62358728/3cada475-5641-42ad-90c7-a278c7784a7f



Test Plan: 
double checked the existing Modals ☝️ 