### PR TITLE
Go back to loading channels from user metadata

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -48,11 +48,11 @@ export function App() {
   const openPanel = location.pathname.split('/')[1];
 
   const allChannelsToOrg =
-    useAPIFetch<Record<string, string | null>>('/channels') ?? {};
+    useAPIFetch<Record<string, string>>('/channels') ?? {};
 
   const allChannelsArray = Object.entries(allChannelsToOrg).reduce(
     (acc, [key, value]) => {
-      acc.push({ id: key, org: value ?? undefined });
+      acc.push({ id: key, org: value });
       return acc;
     },
     [] as Channel[],
@@ -61,8 +61,8 @@ export function App() {
   const channelID = channelIDParam ?? 'general';
   const channel: Channel =
     openPanel === 'channel'
-      ? { id: channelID, org: allChannelsToOrg[channelID] || undefined }
-      : { id: '', org: undefined };
+      ? { id: channelID, org: allChannelsToOrg[channelID] }
+      : { id: '', org: 'clack_all' };
 
   const onOpenThread = (threadID: string) => {
     navigate(`/channel/${channel.id}/thread/${threadID}`);

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -6,6 +6,7 @@ import { SidebarButton } from 'src/client/components/SidebarButton';
 import type { Channel } from 'src/client/consts/Channel';
 import { ChannelsRightClickMenu } from 'src/client/components/ChannelsRightClickMenu';
 import { Overlay } from 'src/client/components/MoreActionsButton';
+import { EVERYONE_ORG_ID } from 'src/client/consts/consts';
 
 export function ChannelButton({
   option,
@@ -72,7 +73,13 @@ export function Channels({
               setContextMenuOpenForChannel(channel);
             }}
             option={channel}
-            icon={channel.org ? <PrivateChannelIcon /> : <ChannelIcon />}
+            icon={
+              channel.org === EVERYONE_ORG_ID ? (
+                <ChannelIcon />
+              ) : (
+                <PrivateChannelIcon />
+              )
+            }
           />
         ))}
         {contextMenuOpenForChannel && (

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -10,7 +10,6 @@ import { Threads } from 'src/client/components/Threads';
 import { PageHeader } from 'src/client/components/PageHeader';
 import { StyledComposer } from 'src/client/components/style/StyledCord';
 import { PageUsersLabel } from 'src/client/components/PageUsersLabel';
-import { EVERYONE_ORG_ID } from 'src/client/consts/consts';
 
 interface ChatProps {
   channel: Channel;
@@ -19,7 +18,7 @@ interface ChatProps {
 
 export function Chat({ channel, onOpenThread }: ChatProps) {
   const { orgMembers, loading, hasMore, fetchMore } = user.useOrgMembers({
-    organizationID: channel.org || EVERYONE_ORG_ID,
+    organizationID: channel.org,
   });
 
   useEffect(() => {

--- a/src/client/components/PinnedMessages.tsx
+++ b/src/client/components/PinnedMessages.tsx
@@ -5,6 +5,7 @@ import { styled } from 'styled-components';
 import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { Modal } from 'src/client/components/Modal';
+import { EVERYONE_ORG_ID } from 'src/client/consts/consts';
 
 interface PinnedMessagesProps extends React.ComponentProps<typeof Modal> {
   channel: Channel;
@@ -20,10 +21,7 @@ export function PinnedMessages({
     <Modal isOpen={isOpen} onClose={onClose}>
       <Box>
         <CloseButton onClick={onClose} />
-        {channel.org ? (
-          // ThreadList does not yet have an organizationId prop.
-          <div>Not yet implemented for private channels</div>
-        ) : (
+        {channel.org === EVERYONE_ORG_ID ? (
           <StyledThreadList
             location={{ channel: channel.id }}
             filter={{ metadata: { pinned: true } }}
@@ -31,6 +29,9 @@ export function PinnedMessages({
               navigate(`/channel/${channel.id}/thread/${threadId}`)
             }
           />
+        ) : (
+          // ThreadList does not yet have an organizationId prop.
+          <div>Not yet implemented for private channels</div>
         )}
       </Box>
     </Modal>

--- a/src/client/consts/Channel.ts
+++ b/src/client/consts/Channel.ts
@@ -1,4 +1,4 @@
 export type Channel = {
   id: string;
-  org: string | undefined;
+  org: string;
 };

--- a/src/server/handlers/getChannels.ts
+++ b/src/server/handlers/getChannels.ts
@@ -17,18 +17,18 @@ export async function handleGetChannels(req: Request, res: Response) {
     .sort((a, b) => a[0].localeCompare(b[0]))
     .reduce(
       (acc, [key, value]) => {
-        if (value === '' || organizations.includes(value)) {
+        if (organizations.includes(value)) {
           acc[key] = value;
         }
         return acc;
       },
       // Special channel: everyone starts with general in their list
-      { general: '' } as Record<string, string | null>,
+      { general: 'clack_all' } as Record<string, string | null>,
     );
 
   // Special channels: everyone gets these testing channels at the end of their list
-  availableChannels['noise'] = '';
-  availableChannels['what-the-quack'] = '';
+  availableChannels['noise'] = 'clack_all';
+  availableChannels['what-the-quack'] = 'clack_all';
 
   res.send(availableChannels);
 }


### PR DESCRIPTION
Reverses https://github.com/getcord/clack/commit/925ee2f010ece6dba1f5444f64325b9ba8d822c5 again 😛

> let's go back to a more reasonable implementation until we can do
something more useful with this technique (e.g., letting people create
their own new channels)

IT IS TIME!

Test Plan: Everything still loads
