### PR TITLE
Rename org members endpoint

### DIFF
--- a/src/client/components/UsersInChannelModal.tsx
+++ b/src/client/components/UsersInChannelModal.tsx
@@ -134,7 +134,7 @@ function UserRow({
           // it looks like nothing's happened in the FE atm
           <DeleteButton
             onClick={() => {
-              void update(`/channels/${org}`, 'DELETE', {
+              void update(`/channelMembers/${org}`, 'DELETE', {
                 userIDs: [user.id],
               });
             }}
@@ -191,7 +191,7 @@ function AddUsersToChannelModal({
   // TODO: the org members API currently doesn't have subscriptions, so
   // it looks like nothing's happened in the FE atm
   const addUsers = useCallback(() => {
-    void update(`/channels/${channel.org}`, 'PUT', {
+    void update(`/channelMembers/${channel.org}`, 'PUT', {
       userIDs: usersToAdd,
     }).then(() => onClose());
   }, [channel.org, onClose, update, usersToAdd]);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -80,8 +80,11 @@ function main() {
   app.get('/users', wrapAsyncHandler(handleGetCordUsers));
   app.get('/usersData', wrapAsyncHandler(handleGetCordUsersData));
 
-  app.put('/channels/:channelName', wrapAsyncHandler(handleAddOrgMember));
-  app.delete('/channels/:channelName', wrapAsyncHandler(handleRemoveOrgMember));
+  app.put('/channelMembers/:channelName', wrapAsyncHandler(handleAddOrgMember));
+  app.delete(
+    '/channelMembers/:channelName',
+    wrapAsyncHandler(handleRemoveOrgMember),
+  );
 
   app.put('/channels/:channelName', wrapAsyncHandler(handleAddChannel));
 


### PR DESCRIPTION
I'm using /channels/:channelName for adding a channel now - so need to
switch the org members one added in https://github.com/getcord/clack/pull/67

Test Plan: :eyes:
