### PR TITLE
Mobile: Close sidebar when opening a thread

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -41,6 +41,7 @@ function useCordToken(): [string | undefined, string | undefined] {
 export function App() {
   const [cordToken, cordUserID] = useCordToken();
   const { channelID: channelIDParam, threadID } = useParams();
+  // We only hide the sidebar on mobile, to regain some space.
   const [showSidebar, setShowSidebar] = React.useState(false);
 
   const navigate = useNavigate();
@@ -67,6 +68,15 @@ export function App() {
   const onOpenThread = (threadID: string) => {
     navigate(`/channel/${channel.id}/thread/${threadID}`);
   };
+
+  // TODO: This should happen onNotificationClick.
+  // Remove this code once that's available.
+  React.useEffect(() => {
+    if (threadID) {
+      // If there's a thread open, hide the sidebar.
+      setShowSidebar(false);
+    }
+  }, [threadID]);
 
   const onCordNavigate: NavigateFn = React.useCallback(
     (_url, location, { threadID }) => {


### PR DESCRIPTION
Summary:
From mobile, if you clicked a notification, the layout would be very broken. This is because we didn't hide the sidebar.

Test plan:
Tried all 3 vieport breakpoints, checked everything still works as expected, and the annoying mobile bug is fixed.