### PR TITLE
Only set channels if defined

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -59,15 +59,17 @@ export function App() {
     () =>
       void fetch('/channels', 'GET')
         .then((allChannelsToOrg: { string: string }) => {
-          setAllChannelsObj(allChannelsToOrg);
-          const allChannelsArray = Object.entries(allChannelsToOrg).reduce(
-            (acc, [key, value]) => {
-              acc.push({ id: key, org: value });
-              return acc;
-            },
-            [] as Channel[],
-          );
-          setAllChannelsArray(allChannelsArray);
+          if (allChannelsToOrg) {
+            setAllChannelsObj(allChannelsToOrg);
+            const allChannelsArray = Object.entries(allChannelsToOrg).reduce(
+              (acc, [key, value]) => {
+                acc.push({ id: key, org: value });
+                return acc;
+              },
+              [] as Channel[],
+            );
+            setAllChannelsArray(allChannelsArray);
+          }
         })
         .catch((e) => console.error(e)),
     [fetch],


### PR DESCRIPTION
There is a little flickering bug at the moment when you try and log into
Clack if you're not authed/your token expired.  Before you get redirected
to Slack to log in, the front end tries to request channels but gets a
401 error back - we log this to the console in useLazyAPIFetch but the
.then on the fetch still tries to set what it gets back as the list of
channels, however what it gets back is undefined.

Test Plan: Clear cookies, refresh.  Consistently no error now.
