### PR TITLE
Add organizationId to thread details composer

### DIFF
--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -129,7 +129,12 @@ export function ThreadDetails({
             />
           ))}
         </MessageListWrapper>
-        <StyledComposer autofocus threadId={threadID} showExpanded />
+        <StyledComposer
+          autofocus
+          threadId={threadID}
+          showExpanded
+          organizationId={channel.org}
+        />
         <TypingIndicator threadID={threadID} organizationID={channel.org} />
       </ScrollableContainer>
     </ThreadDetailsWrapper>


### PR DESCRIPTION
We reverted the Cord-side change that this was relying on, so
temporarily put back the org ID on this composer so that @-mentions
work.

Test Plan: Try to @-mention from thread details, works now.
