### PR TITLE
Temporarily remove threads panel

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -170,7 +170,6 @@ export function App() {
                 <Sidebar
                   channel={channel}
                   allChannels={allChannelsArray}
-                  openPanel={openPanel}
                   setShowSidebar={setShowSidebar}
                 />
                 <MessageProvider>
@@ -182,10 +181,6 @@ export function App() {
                         onOpenThread={onOpenThread}
                       />
                     )}
-
-                    {/* {openPanel === 'threads' && (
-                      <ThreadsList cordUserID={cordUserID} />
-                    )} */}
                   </ResponsiveContent>
                   {threadID && (
                     <ThreadDetails

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { NotificationListLauncher } from '@cord-sdk/react';
-// import { SidebarButton } from 'src/client/components/SidebarButton';
 import type { Channel } from 'src/client/context/ChannelsContext';
 import { Colors } from 'src/client/consts/Colors';
 import { PageHeader } from 'src/client/components/PageHeader';
@@ -13,7 +12,6 @@ type SidebarProps = {
   className?: string;
   channel: Channel;
   allChannels: Channel[];
-  openPanel: string | null;
   setShowSidebar?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
@@ -21,7 +19,6 @@ export function Sidebar({
   className,
   channel,
   allChannels,
-  // openPanel,
   setShowSidebar,
 }: SidebarProps) {
   const navigate = useNavigate();
@@ -33,22 +30,6 @@ export function Sidebar({
         <StyledNotifLauncher />
       </SidebarHeader>
       <ScrollableContent>
-        <Panel>
-          {/* <ThreadsButton
-            option={'Threads'}
-            onClick={() => {
-              navigate('/threads/');
-            }}
-            icon={
-              <ChatBubbleOvalLeftEllipsisIcon
-                style={{ width: '20px', height: '20px' }}
-              />
-            }
-            isActive={openPanel === 'threads'}
-            hasUnread={false}
-          /> */}
-        </Panel>
-        <Divider />
         <Channels
           setCurrentChannelID={(channelID) => {
             navigate(`/channel/${channelID}`);
@@ -91,20 +72,4 @@ const SidebarHeader = styled.div({
 
 const StyledNotifLauncher = styled(NotificationListLauncher)({
   padding: '0 16px',
-});
-
-// const ThreadsButton = styled(SidebarButton)`
-//   width: 100%;
-//   margin: 20px 8px;
-// `;
-
-const Panel = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  margin: '20px 8px 0',
-});
-
-const Divider = styled.div({
-  border: `1px solid ${Colors.purple_border}`,
-  margin: '20px 0',
 });


### PR DESCRIPTION
Summary:
This endpoint hasn't been implemented here with the incoming pagination data - I'll just hide the panel for now as I know it's not used much due to its performance issues then come back later on to update it to work with paginated data.

Test plan:
Open clack locally - threads panel not visible and going to the url doesn't cause any api errors (I'm unable to do this while pointing to a local branch with the API changed due to a weird bug in my system with pointing to my local API endpoint) This should definitely work though 