### PR TITLE
Use new thread APIs in clack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.20.1",
-        "@cord-sdk/server": "^1.20.1",
+        "@cord-sdk/react": "^1.21.0",
+        "@cord-sdk/server": "^1.21.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
         "dotenv": "^16.3.1",
@@ -26,8 +26,8 @@
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
-        "@cord-sdk/api-types": "^1.20.1",
-        "@cord-sdk/types": "^1.20.1",
+        "@cord-sdk/api-types": "^1.21.0",
+        "@cord-sdk/types": "^1.21.0",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/react": "^18.2.16",
@@ -2035,26 +2035,26 @@
       }
     },
     "node_modules/@cord-sdk/api-types": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.20.1.tgz",
-      "integrity": "sha512-be7JjXA8yRPQx+MsKPSxgREzMFAUrsVN2P/PA+Jc86lOtCIHcJ2G34/S+k2DBLKqBqGfc6kWljEc9DxAuhC4ag==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.21.0.tgz",
+      "integrity": "sha512-xSvQj489bdBJ8aL+4lMjaAR394l6FT6hOeA5k0IwwQVRCrqC4O327V+/0O8N++n6Ka4lcuJxmaAxd5MT8OfDOA==",
       "dev": true
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.20.1.tgz",
-      "integrity": "sha512-7oLXdA4nPFb+eJfH63op0FAAUU/oKSey6KRFUeG1ogO2p2XnnP4u6pGUzAT4qQ4haoJyM+poYJX2j7hxZVIyPQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.21.0.tgz",
+      "integrity": "sha512-tnqlyiZiPBOQRoSInOL6krLbH2DQOUBhFZAPJCu4fj4YcqbaCVblGKqteoE7je2Tq4VlJFfqMwfw+pLw7DjZJw==",
       "dependencies": {
-        "@cord-sdk/types": "1.20.1"
+        "@cord-sdk/types": "1.21.0"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.20.1.tgz",
-      "integrity": "sha512-567B+Dar6Epm4FYGFukIlLWZZF69nvDCzKS/pbEvVC/q8bs//pb5HSgF5O/ObtSfCauDoRyTOkpKim66RV+osw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.21.0.tgz",
+      "integrity": "sha512-vVVujYFeJgHOyT2jhuvDu3VZu3sDDEHj9vRfhFAEoVgclO+5UtCviGnHbR61OVKHV5EYqWDRTgiuLa+s/Ktcbg==",
       "dependencies": {
-        "@cord-sdk/components": "1.20.1",
-        "@cord-sdk/types": "1.20.1",
+        "@cord-sdk/components": "1.21.0",
+        "@cord-sdk/types": "1.21.0",
         "classnames": "^2.3.1",
         "phosphor-react": "^1.4.0",
         "radash": "^11.0.0",
@@ -2065,17 +2065,17 @@
       }
     },
     "node_modules/@cord-sdk/server": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.20.1.tgz",
-      "integrity": "sha512-ckm9S5k5DBZUpieqqICmNYm1DvzfSjNQQkP3ydGMh+b1aPEasxL3aCz6hGAbophxWi8USzYcoRpg5S4+6IsNww==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.21.0.tgz",
+      "integrity": "sha512-1zKXD6W7aRgNvpeas5D05uycAIHYgUqcVF5C4cFu7v8BCHJrADnuTqmagLHOo4jKoNOAdNhH+a7duxVLGaFWYw==",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.20.1.tgz",
-      "integrity": "sha512-Em7JnqaemeahAqO9q7wEMlwimDLyiKQgq3djFGRsnY2AWFr2BKlwrdCMkbLr1RYdPZqvfx/oBgmbjJdKzeEdcQ=="
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.21.0.tgz",
+      "integrity": "sha512-9g9CtnlaHeREFNdN0zcapvKBkjaKDn0JBXU5kKMDNimWwg0WC2siGCPBmXNYbJ6WXiiTGX4d+OOVS6Yz2pUiIg=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.20.1",
-    "@cord-sdk/server": "^1.20.1",
+    "@cord-sdk/react": "^1.21.0",
+    "@cord-sdk/server": "^1.21.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",
     "dotenv": "^16.3.1",
@@ -35,8 +35,8 @@
     "styled-components": "^6.0.5"
   },
   "devDependencies": {
-    "@cord-sdk/api-types": "^1.20.1",
-    "@cord-sdk/types": "^1.20.1",
+    "@cord-sdk/api-types": "^1.21.0",
+    "@cord-sdk/types": "^1.21.0",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/react": "^18.2.16",

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -27,10 +27,14 @@ export function ChannelButton({
   isActive: boolean;
   icon: React.ReactNode;
 }) {
-  const summary = thread.useLocationSummary(
-    { channel: option.id },
-    { partialMatch: true },
-  );
+  const summary = thread.useThreadCounts({
+    filter: {
+      location: {
+        value: { channel: option.id },
+        partialMatch: true,
+      },
+    },
+  });
   const hasUnread = !!summary?.new;
 
   return (

--- a/src/client/components/ChannelsRightClickMenu.tsx
+++ b/src/client/components/ChannelsRightClickMenu.tsx
@@ -16,13 +16,13 @@ export function ChannelsRightClickMenu({
   const [threadIDs, setThreadIDs] = useState<Set<string>>(new Set());
   const [shouldMarkAsUnread, setShouldMarkAsUnread] = useState(false);
 
-  const { threads, hasMore, fetchMore, loading } = thread.useLocationData(
-    { channel: channel.id },
-    {
-      sortBy: 'first_message_timestamp',
-      sortDirection: 'descending',
+  const { threads, hasMore, fetchMore, loading } = thread.useThreads({
+    filter: {
+      location: { channel: channel.id },
     },
-  );
+    sortBy: 'first_message_timestamp',
+    sortDirection: 'descending',
+  });
 
   // Don't currently have a way to load just unread threads, so load a fair chunk
   // of recent threads, since presumably newer ones are the ones showing as unread

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -29,16 +29,14 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
     }
   }, [orgMembers, hasMore, loading, fetchMore]);
 
-  const { threads: pinnedThreads } = thread.useLocationData(
-    { channel: channel.id },
-    {
-      filter: {
-        metadata: {
-          pinned: true,
-        },
+  const { threads: pinnedThreads } = thread.useThreads({
+    filter: {
+      location: { channel: channel.id },
+      metadata: {
+        pinned: true,
       },
     },
-  );
+  });
 
   const [showPinnedMessages, setShowPinnedMessages] = useState(false);
   const [isAtBottomOfThreads, setIsAtBottomOfThreads] = useState(false);

--- a/src/client/components/Threads.tsx
+++ b/src/client/components/Threads.tsx
@@ -24,12 +24,10 @@ export function Threads({
   onScrollToBottom,
   onScrollUp,
 }: ThreadsProps) {
-  const { threads, loading, hasMore, fetchMore } = thread.useLocationData(
-    { channel: channel.id },
-    {
-      sortDirection: 'descending',
-    },
-  );
+  const { threads, loading, hasMore, fetchMore } = thread.useThreads({
+    filter: { location: { channel: channel.id } },
+    sortDirection: 'descending',
+  });
   const [unseenMessages, setUnseenMessages] = useState<ThreadSummary[]>([]);
   const threadListRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
Since we're deprecating the 'location' APIs, thought clack would be
a good place to start replacing its usage

Test Plan:
- everything loads up fine locally, I'm able to see pinned messages and
highlighted/unhighlighted channels correctly
