### PR TITLE
Mobile view: hide sidebar when clicking on a notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.21.0",
+        "@cord-sdk/react": "^1.21.1",
         "@cord-sdk/server": "^1.21.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
@@ -2041,20 +2041,20 @@
       "dev": true
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.21.0.tgz",
-      "integrity": "sha512-tnqlyiZiPBOQRoSInOL6krLbH2DQOUBhFZAPJCu4fj4YcqbaCVblGKqteoE7je2Tq4VlJFfqMwfw+pLw7DjZJw==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.21.1.tgz",
+      "integrity": "sha512-BiSTuWzihYJVkpikctV9k40xTyiJswVMjA5U3nbHy2GBAQ3t1UuiUV3Kaoq7MrB32kmBMucOrKfUyfCmvEp4Tw==",
       "dependencies": {
-        "@cord-sdk/types": "1.21.0"
+        "@cord-sdk/types": "1.21.1"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.21.0.tgz",
-      "integrity": "sha512-vVVujYFeJgHOyT2jhuvDu3VZu3sDDEHj9vRfhFAEoVgclO+5UtCviGnHbR61OVKHV5EYqWDRTgiuLa+s/Ktcbg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.21.1.tgz",
+      "integrity": "sha512-m06EPCOP10Ch7hE/e9Y+D1VG+tXQDkg4j1V8el2ehuHcn8N92ORA1UxeDeP8PLMxoAE1LYuP5hibM1UOmzLqGQ==",
       "dependencies": {
-        "@cord-sdk/components": "1.21.0",
-        "@cord-sdk/types": "1.21.0",
+        "@cord-sdk/components": "1.21.1",
+        "@cord-sdk/types": "1.21.1",
         "classnames": "^2.3.1",
         "phosphor-react": "^1.4.0",
         "radash": "^11.0.0",
@@ -2073,9 +2073,9 @@
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.21.0.tgz",
-      "integrity": "sha512-9g9CtnlaHeREFNdN0zcapvKBkjaKDn0JBXU5kKMDNimWwg0WC2siGCPBmXNYbJ6WXiiTGX4d+OOVS6Yz2pUiIg=="
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.21.1.tgz",
+      "integrity": "sha512-oUjHkFYPGr3Ufa+06COv5Ou9RN8bll1UPk6Bgo3qYC8L66I7O71jDRJ8hkUfvMxuBtRMgeNkJ+CvJohE6/E5XQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.21.0",
+    "@cord-sdk/react": "^1.21.1",
     "@cord-sdk/server": "^1.21.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -97,15 +97,6 @@ export function App() {
     navigate(`/channel/${channel.id}/thread/${threadID}`);
   };
 
-  // TODO: This should happen onNotificationClick.
-  // Remove this code once that's available.
-  React.useEffect(() => {
-    if (threadID) {
-      // If there's a thread open, hide the sidebar.
-      setShowSidebar(false);
-    }
-  }, [threadID]);
-
   const onCordNavigate: NavigateFn = React.useCallback(
     (_url, location, { threadID }) => {
       if (!(location && 'channel' in location)) {

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -27,7 +27,9 @@ export function Sidebar({
     <SidebarWrap className={className}>
       <SidebarHeader>
         <PageHeader>Clack</PageHeader>
-        <StyledNotifLauncher />
+        <StyledNotifLauncher
+          onClickNotification={() => setShowSidebar?.(false)}
+        />
       </SidebarHeader>
       <ScrollableContent>
         <Channels


### PR DESCRIPTION
Summary:
Just fixing a TODO we left some time ago. Bumping to v1.21.1 as it fixes one wrinkle with `onClickNotification` for the `NotificationListLauncher`

Test plan:
On a narrow viewport, click on the notification launcher to open it, then click on a notification. We correctly navigate to it, and the sidebar is correctly hidden. (I.e. no behaviour change)