### PR TITLE
Revert "Add organizationId to thread details composer"

### DIFF
--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -129,15 +129,7 @@ export function ThreadDetails({
             />
           ))}
         </MessageListWrapper>
-        <StyledComposer
-          autofocus
-          threadId={threadID}
-          showExpanded
-          // This group ID shouldn't be necessary and is here to temporarily
-          // work around a Cord bug, see
-          // https://github.com/getcord/clack/pull/84
-          groupId={channel.org}
-        />
+        <StyledComposer autofocus threadId={threadID} showExpanded />
         <TypingIndicator threadID={threadID} />
       </ScrollableContainer>
     </ThreadDetailsWrapper>


### PR DESCRIPTION
We've fixed the Cord-side issue this was working around, so let's go
back to the better API (i.e., not specifying this redundant param).

This reverts commit 417c055f74af94e7e01bdb912024827f77695f10.

Test Plan:
Load Clack, try to mention some one in the right-hand thread details
pane, it works.
