### PR TITLE
Use ChannelsContext instead of prop drilling for sidebar

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -158,11 +158,7 @@ export function App() {
                 })}
               >
                 <Topbar userID={cordUserID} setShowSidebar={setShowSidebar} />
-                <Sidebar
-                  channel={channel}
-                  allChannels={allChannelsArray}
-                  setShowSidebar={setShowSidebar}
-                />
+                <Sidebar channel={channel} setShowSidebar={setShowSidebar} />
                 <MessageProvider>
                   <ResponsiveContent>
                     {openPanel === 'channel' && (

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { styled } from 'styled-components';
 import {
   HashtagIcon,
@@ -13,6 +13,7 @@ import { Overlay } from 'src/client/components/MoreActionsButton';
 import { EVERYONE_ORG_ID } from 'src/client/consts/consts';
 import { Colors } from 'src/client/consts/Colors';
 import { AddChannelModals } from 'src/client/components/AddChannelModals';
+import { ChannelsContext } from 'src/client/context/ChannelsContext';
 
 export function ChannelButton({
   option,
@@ -52,12 +53,11 @@ export function ChannelButton({
 export function Channels({
   setCurrentChannelID,
   currentChannel,
-  channels,
 }: {
   setCurrentChannelID: (channel: string) => void;
   currentChannel: Channel;
-  channels: Channel[];
 }) {
+  const { channels } = useContext(ChannelsContext);
   const [contextMenuPosition, setContextMenuPosition] = useState({
     x: 0,
     y: 0,

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -11,16 +11,10 @@ import { NotificationsRequestBanner } from 'src/client/components/NotificationsR
 type SidebarProps = {
   className?: string;
   channel: Channel;
-  allChannels: Channel[];
   setShowSidebar?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-export function Sidebar({
-  className,
-  channel,
-  allChannels,
-  setShowSidebar,
-}: SidebarProps) {
+export function Sidebar({ className, channel, setShowSidebar }: SidebarProps) {
   const navigate = useNavigate();
 
   return (
@@ -38,7 +32,6 @@ export function Sidebar({
             setShowSidebar?.(false);
           }}
           currentChannel={channel}
-          channels={allChannels}
         />
       </ScrollableContent>
       <NotificationsRequestBanner />


### PR DESCRIPTION
We have this context, let's use it.

Test Plan: Load Clack, still see channel list on left.
