### PR TITLE
fix: only load channel icon and name once it's been fetched

### DIFF
--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -43,17 +43,20 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
 
   const showToolbar = pinnedThreads.length > 0 && isAtBottomOfThreads;
 
+  const channelIcon =
+    channel.org === EVERYONE_ORG_ID ? <ChannelIcon /> : <PrivateChannelIcon />;
+
   return (
     <Wrapper>
       <ChannelDetailsBar>
         <PageHeaderWrapper>
           <PageHeader>
-            {channel.org === EVERYONE_ORG_ID ? (
-              <ChannelIcon />
-            ) : (
-              <PrivateChannelIcon />
-            )}{' '}
-            {channel.id}
+            {channel.org && (
+              <>
+                {channelIcon}
+                {channel.id}
+              </>
+            )}
           </PageHeader>
           {orgMembers && (
             <PageUsersLabel users={orgMembers} channel={channel} />


### PR DESCRIPTION
Previously the channel icon was defaulting to a padlock as `channel.org` was undefined. Now we are checking if it's defined before calculating which icon to show. 
I've also added in the channel name into this check as it looks a little nicer to have the whole heading be ready rather than loading them in bits

This video is recorded with "slow 3G" network, so there's a bit of wait time for the page to load 🙃 

https://github.com/getcord/clack/assets/62358728/67458368-f93f-4506-b159-e5b4d02bfd47



