### PR TITLE
chore: close menu after clicking mute / unmute

### DIFF
--- a/src/client/components/ChannelsRightClickMenu.tsx
+++ b/src/client/components/ChannelsRightClickMenu.tsx
@@ -68,7 +68,12 @@ export function ChannelsRightClickMenu({
             <MenuListItemButton onClick={() => setShouldMarkAsUnread(true)}>
               Mark all as read
             </MenuListItemButton>
-            <MenuListItemButton onClick={() => toggleMute(channel.id)}>
+            <MenuListItemButton
+              onClick={() => {
+                toggleMute(channel.id);
+                closeMenu();
+              }}
+            >
               {muted.has(channel.id) ? 'Unmute' : 'Mute'} channel
             </MenuListItemButton>
           </MenuListItem>


### PR DESCRIPTION
Previously clicking `mute` or `unmute` in the right click of the channels list wouldn't close the menu. This PR closes it once clicked.


https://github.com/getcord/clack/assets/62358728/2947482c-52f2-409d-b508-9c5529406c7e

