### PR TITLE
fix: specifically target cord pill to hide in reaction list

### DIFF
--- a/src/client/components/Options.tsx
+++ b/src/client/components/Options.tsx
@@ -106,7 +106,7 @@ const OptionsStyled = styled.div`
   padding: 4px;
   z-index: 1;
 
-  .cord-reaction-list {
+  .cord-reaction-list .cord-pill {
     display: none;
   }
 


### PR DESCRIPTION
Currently we cannot add reactions to threads that don't have any yet! 😱 I introduced this bug with https://github.com/getcord/monorepo/pull/6982

@AlbertQM called it that it would be a breaking change! Here it is 🙃 (Check currently deployed clack :mild-panic-intensifies:

This PR makes the targeting for the hiding of reaction list more specific. Is now happy :) 

https://github.com/getcord/clack/assets/62358728/4323cce6-65ef-4a23-bb5f-f809824ecec7

