### PR TITLE
Don't render composer if we don't yet have an org

### DIFF
--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -88,12 +88,14 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
         channel={channel}
         onOpenThread={onOpenThread}
       />
-      <StyledComposer
-        location={{ channel: channel.id }}
-        threadName={`#${channel.id}`}
-        groupId={channel.org}
-        showExpanded
-      />
+      {channel.org && (
+        <StyledComposer
+          location={{ channel: channel.id }}
+          threadName={`#${channel.id}`}
+          groupId={channel.org}
+          showExpanded
+        />
+      )}
     </Wrapper>
   );
 }


### PR DESCRIPTION
Clack needs to load the list of channels, which doesn't happen
instantly, but it still tries to render the rest of the page until that
is done. We can't render the toplevel composer though because it doesn't
have an org until the channel list is done loading, and that's now an
error as of getcord/monorepo#7097.

Test Plan:
Insert a delay into loading the channel list. The composer now appears
after that is done, with no error in console.