### PR TITLE
Move org check further up to Chat

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -161,7 +161,7 @@ export function App() {
                 <Sidebar channel={channel} setShowSidebar={setShowSidebar} />
                 <MessageProvider>
                   <ResponsiveContent>
-                    {openPanel === 'channel' && (
+                    {openPanel === 'channel' && channel.org && (
                       <Chat
                         key={channel.id}
                         channel={channel}

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -88,14 +88,12 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
         channel={channel}
         onOpenThread={onOpenThread}
       />
-      {channel.org && (
-        <StyledComposer
-          location={{ channel: channel.id }}
-          threadName={`#${channel.id}`}
-          groupId={channel.org}
-          showExpanded
-        />
-      )}
+      <StyledComposer
+        location={{ channel: channel.id }}
+        threadName={`#${channel.id}`}
+        groupId={channel.org}
+        showExpanded
+      />
     </Wrapper>
   );
 }


### PR DESCRIPTION
https://github.com/getcord/clack/pull/99 only loaded the Composer once
the Clack orgs were loaded, because the Composer now errors if it's not
supplied an org and there's no org in the token.

Another place that requires this is user.useOrgMembers, also in the
Chat component.  It doesn't throw but it does log an error which can
be annoying/misleading if you're trying to debug something else, because
it similarly is only an issue for a brief moment while Clack loads the
channels from its servers

Moving the org requirement up is a simple check.  I guess it adds a small
delay to loading a channel but I don't think it will be an issue (and
is just on the first load of Clack, not every time you change channels)

Test Plan: Loading Clack locally looks fine, no error
