### PR TITLE
Don't allow creating a new channel if it already exists

### DIFF
--- a/src/server/handlers/updateChannels.ts
+++ b/src/server/handlers/updateChannels.ts
@@ -8,6 +8,15 @@ export async function handleAddChannel(req: Request, res: Response) {
   const { channelName } = req.params;
   const { isPrivate } = req.body;
 
+  const existingChannels = (
+    await fetchCordRESTApi<ServerUserData>(`users/all_channels_holder`, 'GET')
+  ).metadata;
+
+  if (channelName in existingChannels) {
+    res.status(403).send('Channel already exists');
+    return;
+  }
+
   // If userIDs is sent, it's a private channel, which means we need to create
   // an org for its participants.  If no userIDs are sent, it's a public channel
   // which means it will be associated with the clack_all org.
@@ -27,10 +36,6 @@ export async function handleAddChannel(req: Request, res: Response) {
       }),
     );
   }
-
-  const existingChannels = (
-    await fetchCordRESTApi<ServerUserData>(`users/all_channels_holder`, 'GET')
-  ).metadata;
 
   const response = await fetchCordRESTApi<
     Promise<{


### PR DESCRIPTION
We weren't checking that the channel already exists, just blindly
setting the membership of the org, which would cause you to take over a
private channel if it already existed, whoops!

The frontend doesn't handle the error return terribly well, but this
seems like an edge case enough that isn't worth fixing (since it is
Clack-specific and not a Cord issue).

Test Plan:
Point Clack at local. Create `secret-rolo-fan-club` channel, that fails
now (since that channel already exists, although the org isn't copied by
the bootstrap script). Create a channel that doesn't already exist,
works fine.
