### PR TITLE
Upgrade Cord SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.24.1",
-        "@cord-sdk/server": "^1.24.1",
+        "@cord-sdk/react": "^1.26.0",
+        "@cord-sdk/server": "^1.26.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
         "dotenv": "^16.3.1",
@@ -26,8 +26,7 @@
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
-        "@cord-sdk/api-types": "^1.24.1",
-        "@cord-sdk/types": "^1.24.1",
+        "@cord-sdk/types": "^1.26.0",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/react": "^18.2.16",
@@ -2034,27 +2033,21 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@cord-sdk/api-types": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/api-types/-/api-types-1.24.1.tgz",
-      "integrity": "sha512-LvotyFd3vmrWMMRxiCcnaQw6v853YgRSujCVjeCNCc6rTamZfRakLsqYbM8mn/ufCywF2HkLuTg2D/cRHWXXSg==",
-      "dev": true
-    },
     "node_modules/@cord-sdk/components": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.24.1.tgz",
-      "integrity": "sha512-HdMGtKkq1h+xLI5Glf8JyZjVvJ7SME6sUInNSm2pCwHUoXbfxh6Ohh0k/Myp65Sw+2GbUYWrGU2XROYf/8CvuQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.26.0.tgz",
+      "integrity": "sha512-LvUjpYzzrcWDnVk/cuPH2czw/v6yCJRLGZ/M8G1ygbQkKpoINPpS0Y6IdhdHM0JJ1OuW4rjgw3rPVZtx97HDKg==",
       "dependencies": {
-        "@cord-sdk/types": "1.24.1"
+        "@cord-sdk/types": "1.26.0"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.24.1.tgz",
-      "integrity": "sha512-rLPT259tIXp6xoruStojSBX29gOMgBGfy5SG7TmqCZa67Jd/V3vGUPUkMXpe8V7yEO1XfzIC5Rno56EJj64uYg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.26.0.tgz",
+      "integrity": "sha512-v/pbovWMQsTMo3BfkISPBNbmUnNOz/c83EuZwSI9lxUXw/cAjT9cJVfOxNGEzZiFrtpmseqahoBAmbQ+p7ufsQ==",
       "dependencies": {
-        "@cord-sdk/components": "1.24.1",
-        "@cord-sdk/types": "1.24.1",
+        "@cord-sdk/components": "1.26.0",
+        "@cord-sdk/types": "1.26.0",
         "classnames": "^2.3.1",
         "phosphor-react": "^1.4.0",
         "radash": "^11.0.0",
@@ -2065,17 +2058,17 @@
       }
     },
     "node_modules/@cord-sdk/server": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.24.1.tgz",
-      "integrity": "sha512-e7LwvaPYYTYODOEzmDO2jLgS2DqCWw4X6NlKz+5RhIGoYV2UEts99pp4IfU9HBjMh4ckfdMdOz4IuZMIz0iGTQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.26.0.tgz",
+      "integrity": "sha512-ZC6Y3SPcxphOP94P+QSrOU0zwhbPT5FWpzHO5kraiWJ70l1G0Rxqq3hHmX6AtCiwH/FBiaowC31Yv+fK/5HhrA==",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.24.1.tgz",
-      "integrity": "sha512-J5YCxsxnWJ5Y2+UPb2JW/k5GMeOrDdyP5oPb9HJ7m6dXUla6bHFpG4zv/s6lsfztAsz7nnoNrv/YWT0LhzdWvg=="
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.26.0.tgz",
+      "integrity": "sha512-vnb7ij1L1jbXbcMk2rPJZ4ypSQ1vRbCbOSC0Gs4vGT03+/cb55ykUNDbc9B8WGFhPVDWuJ5RGkw2tzSIR4FK5Q=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.24.1",
-    "@cord-sdk/server": "^1.24.1",
+    "@cord-sdk/react": "^1.26.0",
+    "@cord-sdk/server": "^1.26.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",
     "dotenv": "^16.3.1",
@@ -35,8 +35,7 @@
     "styled-components": "^6.0.5"
   },
   "devDependencies": {
-    "@cord-sdk/api-types": "^1.24.1",
-    "@cord-sdk/types": "^1.24.1",
+    "@cord-sdk/types": "^1.26.0",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/react": "^18.2.16",

--- a/src/client/l10n.ts
+++ b/src/client/l10n.ts
@@ -30,7 +30,6 @@ export function getTranslations(channel: string): Translations {
         remove_task_tooltip: 'Supprimer la tâche',
         create_task_tooltip: 'Créer une tâche',
         attach_file_tooltip: 'Pièce jointe',
-        start_video_msg_tooltip: 'Enregistrer une vidéo',
         remove_file_action: 'Retirer',
         connect_to_slack_action: 'Connectez votre équipe Slack',
         slack_follow_instructions: 'Suivez les instructions',


### PR DESCRIPTION
Also stop depending on `@cord-sdk/api-types`, those types are all in
`@cord-sdk/types` now.