### PR TITLE
Add translations for Clack strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.26.0",
-        "@cord-sdk/server": "^1.26.0",
+        "@cord-sdk/react": "^1.27.2",
+        "@cord-sdk/server": "^1.27.2",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
         "dotenv": "^16.3.1",
@@ -21,12 +21,13 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
+        "react-i18next": "^13.5.0",
         "react-router-dom": "^6.14.2",
         "react-tooltip": "^5.19.0",
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
-        "@cord-sdk/types": "^1.26.0",
+        "@cord-sdk/types": "^1.27.2",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/react": "^18.2.16",
@@ -2034,41 +2035,43 @@
       }
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.26.0.tgz",
-      "integrity": "sha512-LvUjpYzzrcWDnVk/cuPH2czw/v6yCJRLGZ/M8G1ygbQkKpoINPpS0Y6IdhdHM0JJ1OuW4rjgw3rPVZtx97HDKg==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.27.2.tgz",
+      "integrity": "sha512-W3GRYGAZ/IwL3do5+tpTaRfdPTi5950mmnsm7myAzRrwIvJxwO+ly8vLFrMESoJ5r4f2ZKTyin1yZeQ9ySvcXA==",
       "dependencies": {
-        "@cord-sdk/types": "1.26.0"
+        "@cord-sdk/types": "1.27.2"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.26.0.tgz",
-      "integrity": "sha512-v/pbovWMQsTMo3BfkISPBNbmUnNOz/c83EuZwSI9lxUXw/cAjT9cJVfOxNGEzZiFrtpmseqahoBAmbQ+p7ufsQ==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.27.2.tgz",
+      "integrity": "sha512-q7DANT3GA1FhviCQrmBXvA4QD5uZetXfptOfsS6X37XXzaMwxirTZdQXnXXMe5IyfTI+fw9qyxdX2WAhxX8O7A==",
       "dependencies": {
-        "@cord-sdk/components": "1.26.0",
-        "@cord-sdk/types": "1.26.0",
+        "@cord-sdk/components": "1.27.2",
+        "@cord-sdk/types": "1.27.2",
+        "@floating-ui/react-dom": "^1.3.0",
+        "@radix-ui/react-slot": "^1.0.1",
         "classnames": "^2.3.1",
         "phosphor-react": "^1.4.0",
-        "radash": "^11.0.0",
         "react-i18next": "^13.2.2"
       },
       "peerDependencies": {
-        "react": ">=17.0.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@cord-sdk/server": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.26.0.tgz",
-      "integrity": "sha512-ZC6Y3SPcxphOP94P+QSrOU0zwhbPT5FWpzHO5kraiWJ70l1G0Rxqq3hHmX6AtCiwH/FBiaowC31Yv+fK/5HhrA==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.27.2.tgz",
+      "integrity": "sha512-d6ELyssL/NNP2UAT3Ar1IBC7V8rHxwCm+vw7W2Q+ES8ybaqeyVnuSCsDVPX9j+lWmZ1b0jpmoZoC74mZ+4+wfQ==",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.26.0.tgz",
-      "integrity": "sha512-vnb7ij1L1jbXbcMk2rPJZ4ypSQ1vRbCbOSC0Gs4vGT03+/cb55ykUNDbc9B8WGFhPVDWuJ5RGkw2tzSIR4FK5Q=="
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.27.2.tgz",
+      "integrity": "sha512-Ah+cJkZkKSabNB9Rbsuokf5tdMuzCsfk+qNcqT8pL8gsAsB8KA7tD9HIm1AmSFtpnuc6uIIcfG+7CAwL44sO6w=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",
@@ -2513,6 +2516,18 @@
         "@floating-ui/utils": "^0.1.3"
       }
     },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/utils": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
@@ -2661,6 +2676,41 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/router": {
@@ -2828,7 +2878,7 @@
       "version": "15.7.7",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.7.tgz",
       "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.8",
@@ -2846,7 +2896,7 @@
       "version": "18.2.22",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.22.tgz",
       "integrity": "sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2880,7 +2930,7 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.2",
@@ -7507,14 +7557,6 @@
         }
       ]
     },
-    "node_modules/radash": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/radash/-/radash-11.0.0.tgz",
-      "integrity": "sha512-CRWxTFTDff0IELGJ/zz58yY4BDgyI14qSM5OLNKbCItJrff7m7dXbVF0kWYVCXQtPb3SXIVhXvAImH6eT7VLSg==",
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7580,9 +7622,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.2.2.tgz",
-      "integrity": "sha512-+nFUkbRByFwnrfDcYqvzBuaeZb+nACHx+fAWN/pZMddWOCJH5hoc21+Sa/N/Lqi6ne6/9wC/qRGOoQhJa6IkEQ==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
+      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "html-parse-stringify": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.26.0",
-    "@cord-sdk/server": "^1.26.0",
+    "@cord-sdk/react": "^1.27.2",
+    "@cord-sdk/server": "^1.27.2",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",
     "dotenv": "^16.3.1",
@@ -30,12 +30,13 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
+    "react-i18next": "^13.5.0",
     "react-router-dom": "^6.14.2",
     "react-tooltip": "^5.19.0",
     "styled-components": "^6.0.5"
   },
   "devDependencies": {
-    "@cord-sdk/types": "^1.26.0",
+    "@cord-sdk/types": "^1.27.2",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/react": "^18.2.16",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,11 +1,13 @@
 import { CordProvider, PresenceObserver } from '@cord-sdk/react';
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { styled } from 'styled-components';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import type { NavigateFn } from '@cord-sdk/types';
 import cx from 'classnames';
+import { useTranslation } from 'react-i18next';
+import i18n from 'i18next';
 
 import type { Channel } from 'src/client/context/ChannelsContext';
 import { Colors } from 'src/client/consts/Colors';
@@ -20,7 +22,7 @@ import { MessageProvider } from 'src/client/context/MessageContext';
 import { UsersProvider } from 'src/client/context/UsersProvider';
 import { BREAKPOINTS_PX, EVERYONE_ORG_ID } from 'src/client/consts/consts';
 import { ChannelsContext } from 'src/client/context/ChannelsContext';
-import { LANGS, getTranslations, type Language } from 'src/client/l10n';
+import { getCordTranslations, type Language } from 'src/client/l10n';
 import { useStateWithLocalStoragePersistence } from 'src/client/utils';
 
 function useCordToken(): [string | undefined, string | undefined] {
@@ -41,6 +43,7 @@ function useCordToken(): [string | undefined, string | undefined] {
 }
 
 export function App() {
+  const { t } = useTranslation();
   const [cordToken, cordUserID] = useCordToken();
   const { channelID: channelIDParam, threadID } = useParams();
   // We only hide the sidebar on mobile, to regain some space.
@@ -115,14 +118,21 @@ export function App() {
     [navigate],
   );
 
-  const translations = useMemo(() => getTranslations(channel.id), [channel.id]);
+  const translations = useMemo(
+    () => getCordTranslations(channel.id),
+    [channel.id],
+  );
+
+  useEffect(() => {
+    void i18n.changeLanguage(lang);
+  }, [lang]);
 
   return (
     <>
       <GlobalStyle />
       <Helmet>
         <title>
-          #{channel.id} - {LANGS.find((l) => l.lang === lang)?.name}
+          #{channel.id} - {t('name')}
         </title>
       </Helmet>
       <CordProvider

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -6,6 +6,7 @@ import {
   PlusIcon,
 } from '@heroicons/react/20/solid';
 import { thread } from '@cord-sdk/react';
+import { useTranslation } from 'react-i18next';
 import { SidebarButton } from 'src/client/components/SidebarButton';
 import type { Channel } from 'src/client/consts/Channel';
 import { ChannelsRightClickMenu } from 'src/client/components/ChannelsRightClickMenu';
@@ -62,6 +63,7 @@ export function Channels({
   setCurrentChannelID: (channel: string) => void;
   currentChannel: Channel;
 }) {
+  const { t } = useTranslation();
   const { channels: unsortedChannels } = useContext(ChannelsContext);
   const [contextMenuPosition, setContextMenuPosition] = useState({
     x: 0,
@@ -119,7 +121,7 @@ export function Channels({
           <PlusIconWrapper>
             <PlusIcon width={12} />
           </PlusIconWrapper>
-          <AddChannelsButtonText>Add channels</AddChannelsButtonText>
+          <AddChannelsButtonText>{t('add_channels')}</AddChannelsButtonText>
         </AddChannelsButton>
         <AddChannelModals isOpen={modalOpen} setModalOpen={setModalOpen} />
         {contextMenuOpenForChannel && (

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { thread, user } from '@cord-sdk/react';
 import { HashtagIcon, LockClosedIcon } from '@heroicons/react/20/solid';
+import { useTranslation } from 'react-i18next';
 import type { Channel } from 'src/client/context/ChannelsContext';
 import { PinnedMessages } from 'src/client/components/PinnedMessages';
 import { Toolbar } from 'src/client/components/Toolbar';
@@ -19,6 +20,7 @@ interface ChatProps {
 }
 
 export function Chat({ channel, onOpenThread }: ChatProps) {
+  const { t } = useTranslation();
   const { orgMembers, loading, hasMore, fetchMore } = user.useOrgMembers({
     organizationID: channel.org,
   });
@@ -70,7 +72,7 @@ export function Chat({ channel, onOpenThread }: ChatProps) {
           }}
           onClick={() => setShowPinnedMessages(true)}
         >
-          <PushPinIcon /> {pinnedThreads.length} Pinned
+          <PushPinIcon /> {t('pinned_threads', { count: pinnedThreads.length })}
         </span>
       </Toolbar>
       <PinnedMessages

--- a/src/client/components/DateDivider.tsx
+++ b/src/client/components/DateDivider.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { styled } from 'styled-components';
+import { useTranslation } from 'react-i18next';
 import { Colors } from 'src/client/consts/Colors';
 
 export function DateDivider({ timestamp }: { timestamp: Date }) {
+  const { t, i18n } = useTranslation();
   const now = new Date();
   const isToday =
     now.getFullYear() === timestamp.getFullYear() &&
@@ -13,8 +15,8 @@ export function DateDivider({ timestamp }: { timestamp: Date }) {
       <Line />
       <Pill>
         {isToday
-          ? 'Today'
-          : timestamp.toLocaleDateString('en-GB', {
+          ? t('today')
+          : timestamp.toLocaleDateString(i18n.language, {
               weekday: 'short',
               month: 'long',
               day: 'numeric',

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { NotificationListLauncher } from '@cord-sdk/react';
 import type { Channel } from 'src/client/context/ChannelsContext';
 import { Colors } from 'src/client/consts/Colors';
@@ -25,19 +26,20 @@ export function Sidebar({
   lang,
   setLang,
 }: SidebarProps) {
+  const { t } = useTranslation('translation');
   const navigate = useNavigate();
 
   return (
     <SidebarWrap className={className}>
       <SidebarHeader>
-        <ClackHeader>{LANGS.find((l) => l.lang === lang)?.name}</ClackHeader>
+        <ClackHeader>{t('name')}</ClackHeader>
         <LangSelector
           value={lang}
           onChange={(e) => setLang(e.target.value as Language)}
         >
           {LANGS.map((l) => (
-            <option key={l.lang} value={l.lang}>
-              {l.lang}
+            <option key={l} value={l}>
+              {l}
             </option>
           ))}
         </LangSelector>

--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -3,6 +3,7 @@ import { styled } from 'styled-components';
 import { thread } from '@cord-sdk/react/';
 import { XMarkIcon } from '@heroicons/react/20/solid';
 import type { CoreMessageData, ThreadSummary } from '@cord-sdk/types';
+import { useTranslation } from 'react-i18next';
 import type { Channel } from 'src/client/context/ChannelsContext';
 import { PageHeader } from 'src/client/components/PageHeader';
 import { Colors } from 'src/client/consts/Colors';
@@ -78,22 +79,22 @@ export function ThreadDetails({
   onClose,
   channel,
 }: ThreadDetailsProps) {
+  const { t } = useTranslation();
   const { messages, loading, hasMore, fetchMore } =
     thread.useThreadData(threadID);
 
   const threadSummary = thread.useThreadSummary(threadID);
 
   if (!threadSummary || messages.length === 0) {
-    return <div>Loading messages...</div>;
+    return <div>{t('loading_messages')}</div>;
   }
 
   const numReplies = threadSummary.total - 1;
-  const replyWord = numReplies === 1 ? 'reply' : 'replies';
 
   return (
     <ThreadDetailsWrapper className={className}>
       <ThreadDetailsHeader>
-        <span style={{ gridArea: 'thread' }}>Thread</span>
+        <span style={{ gridArea: 'thread' }}>{t('thread_header')}</span>
         <ChannelName># {channel.id}</ChannelName>
         <CloseButton onClick={onClose}>
           <StyledXMarkIcon />
@@ -110,7 +111,7 @@ export function ThreadDetails({
             {numReplies > 0 ? (
               <>
                 <SeparatorText>
-                  {numReplies} {replyWord}
+                  {t('replies', { count: numReplies })}
                 </SeparatorText>
                 <SeparatorLine />
               </>

--- a/src/client/components/ThreadReplies.tsx
+++ b/src/client/components/ThreadReplies.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Facepile, Timestamp } from '@cord-sdk/react';
 import { styled } from 'styled-components';
 import type { ThreadSummary } from '@cord-sdk/types';
+import { Trans, useTranslation } from 'react-i18next';
 import { Colors } from 'src/client/consts/Colors';
 
 const RepliesWrapper = styled.div({
@@ -53,6 +54,7 @@ type ThreadRepliesProps = {
 };
 
 export function ThreadReplies({ summary, onOpenThread }: ThreadRepliesProps) {
+  const { t } = useTranslation();
   const numReplies = summary.total - 1;
   if (numReplies < 1) {
     return null;
@@ -62,15 +64,18 @@ export function ThreadReplies({ summary, onOpenThread }: ThreadRepliesProps) {
     summary.lastMessage?.updatedTimestamp ??
     summary.lastMessage?.createdTimestamp;
 
-  const replyWord = numReplies === 1 ? 'reply' : 'replies';
   return (
     <RepliesWrapper onClick={(_e) => onOpenThread(summary.id)}>
       <Facepile users={summary.repliers} />{' '}
-      <RepliesCount>
-        {summary.total - 1} {replyWord}
-      </RepliesCount>
+      <RepliesCount>{t('replies', { count: numReplies })}</RepliesCount>
       <RepliesTimestamp>
-        Last reply <StyledTimestamp value={lastReplyTime} />
+        <Trans
+          t={t}
+          i18nKey={'last_reply'}
+          components={{
+            timestamp: <StyledTimestamp value={lastReplyTime} />,
+          }}
+        ></Trans>
       </RepliesTimestamp>
     </RepliesWrapper>
   );

--- a/src/client/l10n.ts
+++ b/src/client/l10n.ts
@@ -1,23 +1,78 @@
 import type { Translations } from '@cord-sdk/types';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 
-export const LANGS = [
-  {
-    lang: 'en',
-    name: 'Clack',
-  },
-  {
-    lang: 'fr',
-    name: 'Claque',
-  },
-  {
-    lang: 'he',
-    name: 'קלאק',
-  },
-] as const;
+export const LANGS = ['en', 'fr', 'he'] as const;
+export type Language = (typeof LANGS)[number];
 
-export type Language = (typeof LANGS)[number]['lang'];
+const resources = {
+  en: {
+    translation: {
+      name: 'Clack',
+      today: 'Today',
+      replies_one: '1 reply',
+      replies_other: '{{count}} replies',
+      thread_header: 'Thread',
+      loading_messages: 'Loading messages...',
+      add_channels: 'Add channels',
+      pinned_threads_one: '1 Pinned',
+      pinned_threads_other: '{{count}} Pinned',
+      last_reply: 'Last reply <timestamp>',
+    },
+  },
+  fr: {
+    translation: {
+      name: 'Claque',
+      today: "Aujourd'hui",
+      replies_one: '1 réponse',
+      replies_other: '{{count}} réponses',
+      thread_header: 'Fil de discussion',
+      loading_messages: 'Chargement en cours...',
+      add_channels: 'Ajouter des chaînes',
+      pinned_threads_one: '1 épinglé',
+      pinned_threads_other: '{{count}} épinglés',
+      last_reply: 'Dernière réponse <timestamp>',
+    },
+  },
+  he: {
+    translation: {
+      name: 'קלאק',
+      today: 'היום',
+      replies_one: 'תגובה אחת',
+      replies_two: '{{count}} תגובות',
+      replies_other: '{{count}} תגובות',
+      thread_header: 'שרשור',
+      loading_messages: 'טוען הודעות...',
+      add_channels: 'הוסף ערוצים',
+      pinned_threads_one: '1 מוצמד',
+      pinned_threads_two: '{{count}} מוצמדים',
+      pinned_threads_other: '{{count}} מוצמדים',
+      last_reply: 'תשובה אחרונה <timestamp>',
+    },
+  },
+} as const;
 
-export function getTranslations(channel: string): Translations {
+void i18n
+  .use(initReactI18next) // passes i18n down to react-i18next
+  .init({
+    resources,
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
+    },
+  });
+
+// This tells i18next what shape the resources file is, which then feeds into
+// the TypeScript types in a very clever way so that when you ask for a
+// translation key, it can check that you're using a key that exists.
+declare module 'i18next' {
+  export interface CustomTypeOptions {
+    resources: (typeof resources)['en'];
+  }
+}
+
+export function getCordTranslations(channel: string): Translations {
   return {
     en: {
       composer: {


### PR DESCRIPTION
This lets us prove out that mixing i18next from customer code and our
NPM package works fine.  I've intentionally chosen a different version
of react-i18next than `@cord-sdk/react` uses to increase the chance of
conflict.