### PR TITLE
After login, make sure user is member of clack_all

### DIFF
--- a/src/server/handlers/login.ts
+++ b/src/server/handlers/login.ts
@@ -191,8 +191,8 @@ function redirectToSlackLogin(req: Request, res: Response) {
 
 async function ensureMemberOfEveryoneOrg(userID: string) {
   // Make sure the user exists. Their details are put into their token and get
-  // set that way, so we don't need to do actually set any fields here (which
-  // lets us do this unconditionally since it won't overwrite anything).
+  // set that way, so we don't need to actually set any fields here (which lets
+  // us do this unconditionally since it won't overwrite anything).
   await fetchCordRESTApi(`users/${userID}`, 'PUT');
 
   // Adding a user who is already a member is explicitly documented as not an


### PR DESCRIPTION
We used to rely on this being the org in their token to add them, but
Clack uses the new privacy model, so we need to do this by hand. Any
current employees will already be members, so this only matters for new
employees (where I fixed things by hand the one time it's come up so
far).

Test Plan:
Change the code to authenticate me as a brand-new fake user. Can still
log into Clack and end up as a member of `clack_all`.
