### PR TITLE
Hacky suppression of website-events new messages

### DIFF
--- a/src/client/components/ChannelThreadCountFetcher.tsx
+++ b/src/client/components/ChannelThreadCountFetcher.tsx
@@ -1,0 +1,28 @@
+import { thread } from '@cord-sdk/react';
+
+/**
+ * Just a hack so that we can conditionally call a hook that was in Channels.tsx
+ */
+
+export function ChannelThreadCountFetcher({
+  setHasUnread,
+  channelID,
+  isMuted,
+}: {
+  setHasUnread: React.Dispatch<React.SetStateAction<boolean>>;
+  channelID: string;
+  isMuted: boolean;
+}) {
+  const summary = thread.useThreadCounts({
+    filter: {
+      location: {
+        value: { channel: channelID },
+        partialMatch: true,
+      },
+    },
+  });
+
+  setHasUnread(!isMuted && !!summary?.new);
+
+  return null;
+}

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -5,7 +5,6 @@ import {
   LockClosedIcon,
   PlusIcon,
 } from '@heroicons/react/20/solid';
-import { thread } from '@cord-sdk/react';
 import { useTranslation } from 'react-i18next';
 import { SidebarButton } from 'src/client/components/SidebarButton';
 import type { Channel } from 'src/client/consts/Channel';
@@ -16,6 +15,7 @@ import { AddChannelModals } from 'src/client/components/AddChannelModals';
 import { ChannelsContext } from 'src/client/context/ChannelsContext';
 import { useMutedChannels } from 'src/client/hooks/useMutedChannels';
 import { ChannelPicker } from 'src/client/components/ChannelPicker';
+import { ChannelThreadCountFetcher } from 'src/client/components/ChannelThreadCountFetcher';
 
 type ChannelWithMute = Channel & { muted: boolean };
 
@@ -32,26 +32,32 @@ export function ChannelButton({
   isActive: boolean;
   icon: React.ReactNode;
 }) {
-  const summary = thread.useThreadCounts({
-    filter: {
-      location: {
-        value: { channel: option.id },
-        partialMatch: true,
-      },
-    },
-  });
-  const hasUnread = !option.muted && !!summary?.new;
+  // Just show website-events as always unread. Lol.  Because we were having perf
+  // issues regarding subscriptions for its thread counts.
+  const [hasUnread, setHasUnread] = useState<boolean>(
+    option.id === 'website-events',
+  );
 
   return (
-    <SidebarButton
-      option={option.id}
-      isActive={isActive}
-      isMuted={option.muted}
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      hasUnread={hasUnread}
-      icon={icon}
-    />
+    <>
+      {/* See comment above.... don't fetch thread counts for website-events */}
+      {option.id !== 'website-events' && (
+        <ChannelThreadCountFetcher
+          setHasUnread={setHasUnread}
+          channelID={option.id}
+          isMuted={option.muted}
+        />
+      )}
+      <SidebarButton
+        option={option.id}
+        isActive={isActive}
+        isMuted={option.muted}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        hasUnread={hasUnread}
+        icon={icon}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
We think that the thread count subscription set up by useThreadCounts to
power whether channels are bold (unread) or not is having an unpleasant
impact on the db in the case of website-events, see e.g.
https://getcord.slack.com/archives/C0156HZ0YLU/p1706093460385269

Test Plan:
Start Clack locally (ok to use prod sdk)
Unmute my website-events channel so I see if it shows as unread or not
Before change: shows as unread

After
```
{option.id !== 'website-events' && (
        <ChannelThreadCountFetcher
          setHasUnread={setHasUnread}
          channelID={option.id}
          isMuted={option.muted}
        />
      )}
```
change but with `hasUnread` state intitialised as `false` - website-events
just shows as read (not bold)

And then with the initialisation of `option.id === 'website-events'` it
always shows as read
