### PR TITLE
Update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.36.3-canary.1",
+        "@cord-sdk/react": "^1.36.3-canary.0",
         "@cord-sdk/server": "^1.32.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
@@ -2035,25 +2035,25 @@
       }
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.36.3-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.36.3-canary.1.tgz",
-      "integrity": "sha512-AdAYG3L2WtVmxIg2X/ayFQKC2TpKNgfiXnxrVIcyByp/84Ig6vuwK1dDt72TbcVoaEoa63p8/Bp0J1bX633n5A==",
+      "version": "1.36.3-canary.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.36.3-canary.0.tgz",
+      "integrity": "sha512-3EdiTJe2DIRzwctSHW5l5FkrrMuUHgLQ2moAqeDo1hME2MJEAbJgiAiG4nawmKDdsKM8iR6D+Hasquy7hoUhGw==",
       "dependencies": {
-        "@cord-sdk/types": "1.36.3-canary.1"
+        "@cord-sdk/types": "1.36.3-canary.0"
       }
     },
     "node_modules/@cord-sdk/components/node_modules/@cord-sdk/types": {
-      "version": "1.36.3-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.3-canary.1.tgz",
-      "integrity": "sha512-tySDu38N6LTMeekcRKk4rWGwC+T4wWv5a+GJm1GE7aNLV6A5/yUmSoWkR1z9PlU33FSQv85c2waFYCQPl5VYKg=="
+      "version": "1.36.3-canary.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.3-canary.0.tgz",
+      "integrity": "sha512-i+WkLeLje8hLyn+mQZIxKhMv6hWCRtSwzUwIsOAEbvLZgsY8GQBfUj6P97N1wcpapO+hWp6iEiOjYat8wRlqrA=="
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.36.3-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.36.3-canary.1.tgz",
-      "integrity": "sha512-OV/citpG+qQ4W3LbOkjTm1x7pWRZBSTT7aCEgdx4+EsbqHAfyABj6tqpG5Abg86RCi/pfBjReVOMpRMIUmTrZg==",
+      "version": "1.36.3-canary.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.36.3-canary.0.tgz",
+      "integrity": "sha512-7c473kTTAKOiBWMScRQu1xK13UmqE3U7x1TvRCK/z85a6rKwB4gMkpN2qgF6KSFB3lVFW7AL5O83AhUasASAWg==",
       "dependencies": {
-        "@cord-sdk/components": "1.36.3-canary.1",
-        "@cord-sdk/types": "1.36.3-canary.1",
+        "@cord-sdk/components": "1.36.3-canary.0",
+        "@cord-sdk/types": "1.36.3-canary.0",
         "@floating-ui/react-dom": "^1.3.0",
         "@radix-ui/react-slot": "^1.0.1",
         "classnames": "^2.5.1",
@@ -2074,6 +2074,7 @@
         "slate-history": "^0.100.0",
         "slate-hyperscript": "^0.100.0",
         "slate-react": "^0.100.0",
+        "use-sync-external-store": "^1.2.0",
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
@@ -2082,9 +2083,9 @@
       }
     },
     "node_modules/@cord-sdk/react/node_modules/@cord-sdk/types": {
-      "version": "1.36.3-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.3-canary.1.tgz",
-      "integrity": "sha512-tySDu38N6LTMeekcRKk4rWGwC+T4wWv5a+GJm1GE7aNLV6A5/yUmSoWkR1z9PlU33FSQv85c2waFYCQPl5VYKg=="
+      "version": "1.36.3-canary.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.3-canary.0.tgz",
+      "integrity": "sha512-i+WkLeLje8hLyn+mQZIxKhMv6hWCRtSwzUwIsOAEbvLZgsY8GQBfUj6P97N1wcpapO+hWp6iEiOjYat8wRlqrA=="
     },
     "node_modules/@cord-sdk/server": {
       "version": "1.32.0",
@@ -9316,6 +9317,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.36.3-canary.1",
+    "@cord-sdk/react": "^1.36.3-canary.0",
     "@cord-sdk/server": "^1.32.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",


### PR DESCRIPTION
### Summary

This PR upgrades the `@cord-sdk/react` package to `1.36.3-canary.0`. This is mainly so that messages are marked as read

