### PR TITLE
Fixing layout message

### DIFF
--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -119,12 +119,20 @@ function MessageWithPaginationTrigger(props: ExperimentalMessageProps) {
     hasMore === undefined
   ) {
     return (
-      <ClackMessage message={props.message} onOpenThread={EMPTY_FUNCTION} />
+      <ClackMessage
+        message={props.message}
+        onOpenThread={EMPTY_FUNCTION}
+        inThreadDetails
+      />
     );
   }
   return (
     <>
-      <ClackMessage message={props.message} onOpenThread={EMPTY_FUNCTION} />
+      <ClackMessage
+        message={props.message}
+        onOpenThread={EMPTY_FUNCTION}
+        inThreadDetails
+      />
       <SeparatorWrap>
         {numReplies > 0 ? (
           <>

--- a/src/client/components/ThreadReplies.tsx
+++ b/src/client/components/ThreadReplies.tsx
@@ -11,6 +11,7 @@ import {
 
 const RepliesWrapper = styled.div<{ $cordVersion: CordVersion }>`
   && {
+    grid-area: replies;
     cursor: pointer;
     display: flex;
     border-radius: 6px;

--- a/src/client/components/style/StyledCord.tsx
+++ b/src/client/components/style/StyledCord.tsx
@@ -140,15 +140,30 @@ export const StyledMessage = styled(Message)<{ $statusEmoji?: string }>`
   }
 `;
 
-export const StyledExperimentalMessage = styled(experimental.Message)`
+export const StyledExperimentalMessage = styled(experimental.Message)<{
+  $hasReplies: boolean;
+  $hasReactions: boolean;
+}>`
   &.cord-message {
     padding: 0;
     align-items: flex-start;
     background-color: inherit;
-    grid-template-columns: auto auto auto auto 1fr auto;
     padding: 8px 20px;
     position: relative;
     transition: background-color 0.2s;
+
+    grid-template-columns: auto auto auto auto 1fr auto;
+
+    grid-template-rows: ${({ $hasReplies, $hasReactions }) =>
+      `24px auto auto ${$hasReplies ? 'auto' : ''} ${
+        $hasReactions ? 'auto' : ''
+      }`};
+
+    grid-template-areas: ${({ $hasReplies, $hasReactions }) =>
+      `'avatar authorName timestamp sentViaIcon . optionsMenu'
+      '. messageContent messageContent messageContent messageContent optionsMenu'
+      ${$hasReactions ? `'. reactions reactions reactions reactions .'` : ''}
+      ${$hasReplies ? `'. replies replies replies replies .'` : ''}`};
 
     &:hover {
       background-color: ${Colors.gray_highlight};


### PR DESCRIPTION
## Summary

The grid was completely bonkers when there are replies but no reactions.

Now, instead of having reactions and replies in the same div, they are separate. Also, setting the grid we want in ClackMessage, depending on whether a message has reactions or replies

## Test plan
![Screenshot 2024-04-03 at 11.07.50.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/4TJIH6mZTWPlG8Bjs63m/888aa819-9d47-4453-84c6-46e11ba771b6.png)

I checked with attachments and it still works.