### PR TITLE
Update types and server package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@cord-sdk/react": "^1.36.3-canary.4",
-        "@cord-sdk/server": "^1.32.0",
+        "@cord-sdk/server": "^1.36.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
         "dotenv": "^16.3.1",
@@ -27,7 +27,7 @@
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
-        "@cord-sdk/types": "^1.32.0",
+        "@cord-sdk/types": "^1.36.0",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/react": "^18.2.16",
@@ -2088,17 +2088,17 @@
       "integrity": "sha512-tueuYcJrANioL0Ylyl48sCEYbL1nudQyZ+O3giMFJe3fdKcFI+/MnwBrj984QVHNUK1+didNjLLqOfvDBpaU8g=="
     },
     "node_modules/@cord-sdk/server": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.32.0.tgz",
-      "integrity": "sha512-p5z2iG00fnTTGGXWFdMN1JPPDAGk9XlAg+TXBk758ujkQDVE3gO033j2tOUpqrQgbUmJgW+Yiv5kpyS4+CjIsw==",
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.36.2.tgz",
+      "integrity": "sha512-sjGHAHpuEk+whxUEIKTHO8TgeIflA2yQ8l6vkcRvNxj9InJn9utVQSlFMzecx0SS3uMt+ryEuWUkWTdD/7AGnA==",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.32.0.tgz",
-      "integrity": "sha512-wZHr+Hlvd7XR68hVGzz0ps6LIyMtn4MIFUXHafGChF2pfcdKxlTeRXOzMebMqJUzCCWzCn36C0uLtGkLKUGH8Q==",
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.2.tgz",
+      "integrity": "sha512-mt3azBVB+vTAyuq9FKVqCvgTfqmVimc2Bfe762PSL3p5AE/AP3Q0dXeiPql2ScmEZ8QxkPQoWSFGGKohUcN/Ag==",
       "dev": true
     },
     "node_modules/@emotion/is-prop-valid": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@cord-sdk/react": "^1.36.3-canary.4",
-    "@cord-sdk/server": "^1.32.0",
+    "@cord-sdk/server": "^1.36.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",
     "dotenv": "^16.3.1",
@@ -36,7 +36,7 @@
     "styled-components": "^6.0.5"
   },
   "devDependencies": {
-    "@cord-sdk/types": "^1.32.0",
+    "@cord-sdk/types": "^1.36.0",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/react": "^18.2.16",


### PR DESCRIPTION
We changed the layout of our packages, so doing this makes it easier to
inject things from monorepo.

Test Plan: Clack still works.
