### PR TITLE
Update SDK to 1.37.1-canary.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.36.3-canary.4",
+        "@cord-sdk/react": "^1.37.1-canary.1",
         "@cord-sdk/server": "^1.36.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
@@ -2035,27 +2035,28 @@
       }
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.36.3-canary.4",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.36.3-canary.4.tgz",
-      "integrity": "sha512-FSJTETLcZXbZv2Gy9yKCE97S3jS2tW3Ycl4iw1nUGYMCbcOUgw7xsHcGTIf4tS1NfHfoH+/XuqijHQckk4LeEw==",
+      "version": "1.37.1-canary.1",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.37.1-canary.1.tgz",
+      "integrity": "sha512-dozqRaoJZvlQkMZju3RKw2zSaqRWt4kOLJqHLud+xrVis+rfMhJSafzBgR1cLKRM6ms47FZeM1g4ty1gjtWUUQ==",
       "dependencies": {
-        "@cord-sdk/types": "1.36.3-canary.4"
+        "@cord-sdk/types": "1.37.1-canary.1"
       }
     },
     "node_modules/@cord-sdk/components/node_modules/@cord-sdk/types": {
-      "version": "1.36.3-canary.4",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.3-canary.4.tgz",
-      "integrity": "sha512-tueuYcJrANioL0Ylyl48sCEYbL1nudQyZ+O3giMFJe3fdKcFI+/MnwBrj984QVHNUK1+didNjLLqOfvDBpaU8g=="
+      "version": "1.37.1-canary.1",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.37.1-canary.1.tgz",
+      "integrity": "sha512-9PG17oPPjaJkG5PrQaqV3GXbBq1uwFXR5hP2t7yMuVm377P8p2olshQCVQ596YVzzGBfMab+cTkEoMolsabRWQ=="
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.36.3-canary.4",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.36.3-canary.4.tgz",
-      "integrity": "sha512-fy3ujOucyJysheS2MhBYR0YMdmbJZ3ZmMvo5TtvxOwW4qmUki50y65hqgovFVlaTjn/EGqVSLoz4HmeKxI1IKA==",
+      "version": "1.37.1-canary.1",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.37.1-canary.1.tgz",
+      "integrity": "sha512-i60YY4YiLis0m+vnqC/YuYjbNiRkn4Qdp/flcPAtZ4avnwdJPW47QtTOnNyUUs27nNsePXkL4HPiNC/eGJK2FQ==",
       "dependencies": {
-        "@cord-sdk/components": "1.36.3-canary.4",
-        "@cord-sdk/types": "1.36.3-canary.4",
+        "@cord-sdk/components": "1.37.1-canary.1",
+        "@cord-sdk/types": "1.37.1-canary.1",
         "@floating-ui/react-dom": "^1.3.0",
         "@radix-ui/react-slot": "^1.0.1",
+        "@vanilla-extract/css": "^1.13.0",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.9",
         "emoji-js": "^3.8.0",
@@ -2083,9 +2084,9 @@
       }
     },
     "node_modules/@cord-sdk/react/node_modules/@cord-sdk/types": {
-      "version": "1.36.3-canary.4",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.3-canary.4.tgz",
-      "integrity": "sha512-tueuYcJrANioL0Ylyl48sCEYbL1nudQyZ+O3giMFJe3fdKcFI+/MnwBrj984QVHNUK1+didNjLLqOfvDBpaU8g=="
+      "version": "1.37.1-canary.1",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.37.1-canary.1.tgz",
+      "integrity": "sha512-9PG17oPPjaJkG5PrQaqV3GXbBq1uwFXR5hP2t7yMuVm377P8p2olshQCVQ596YVzzGBfMab+cTkEoMolsabRWQ=="
     },
     "node_modules/@cord-sdk/server": {
       "version": "1.36.2",
@@ -2100,6 +2101,11 @@
       "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.2.tgz",
       "integrity": "sha512-mt3azBVB+vTAyuq9FKVqCvgTfqmVimc2Bfe762PSL3p5AE/AP3Q0dXeiPql2ScmEZ8QxkPQoWSFGGKohUcN/Ag==",
       "dev": true
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",
@@ -3197,6 +3203,29 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vanilla-extract/css": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.14.2.tgz",
+      "integrity": "sha512-OasEW4ojGqqRiUpsyEDUMrSkLnmwbChtafkogpCZ1eDAgAZ9eY9CHLYodj2nB8aV5T25kQ5shm92k25ngjYhhg==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@vanilla-extract/private": "^1.0.4",
+        "chalk": "^4.1.1",
+        "css-what": "^6.1.0",
+        "cssesc": "^3.0.0",
+        "csstype": "^3.0.7",
+        "deep-object-diff": "^1.1.9",
+        "deepmerge": "^4.2.2",
+        "media-query-parser": "^2.0.2",
+        "modern-ahocorasick": "^1.0.0",
+        "outdent": "^0.8.0"
+      }
+    },
+    "node_modules/@vanilla-extract/private": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.4.tgz",
+      "integrity": "sha512-8FGD6AejeC/nXcblgNCM5rnZb9KXa4WNkR03HCWtdJBpANjTgjHEglNLFnhuvdQ78tC6afaxBPI+g7F2NX3tgg=="
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3265,7 +3294,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3971,7 +3999,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4053,7 +4080,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4064,8 +4090,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4285,6 +4310,28 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
@@ -4316,6 +4363,19 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deep-object-diff": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
+      "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA=="
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-browser": {
       "version": "4.0.0",
@@ -5801,7 +5861,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6879,6 +6938,14 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/media-query-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/media-query-parser/-/media-query-parser-2.0.2.tgz",
+      "integrity": "sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6995,6 +7062,11 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
       "dev": true
+    },
+    "node_modules/modern-ahocorasick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modern-ahocorasick/-/modern-ahocorasick-1.0.1.tgz",
+      "integrity": "sha512-yoe+JbhTClckZ67b2itRtistFKf8yPYelHLc7e5xAwtNAXxM6wJTUx2C7QeVSJFDzKT7bCIFyBVybPMKvmB9AA=="
     },
     "node_modules/moment": {
       "version": "2.29.4",
@@ -7384,6 +7456,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -8876,7 +8953,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.36.3-canary.4",
+    "@cord-sdk/react": "^1.37.1-canary.1",
     "@cord-sdk/server": "^1.36.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",


### PR DESCRIPTION
Summary:
Updating it to get the latest CSS for Cord 4.0 components.

Test plan:
Load Clack locally, check the [CSS is served](https://app.staging.cord.com/sdk/css/1.37.1-canary.1/react-1.37.1-canary.1.css) correctly and Clack looks mostly OK

<img width="1100" alt="image" src="https://github.com/getcord/clack/assets/33761650/5f668b64-333e-4e0e-b470-a2885b48bc7d">

<img width="1111" alt="image" src="https://github.com/getcord/clack/assets/33761650/0a650564-6145-496d-af06-f976c166f6b7">

