### PR TITLE
Update SDK to 1.38.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.37.1-canary.1",
+        "@cord-sdk/react": "^1.38.0",
         "@cord-sdk/server": "^1.36.0",
         "@heroicons/react": "^2.0.18",
         "@slack/web-api": "^6.8.1",
@@ -2035,25 +2035,20 @@
       }
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.37.1-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.37.1-canary.1.tgz",
-      "integrity": "sha512-dozqRaoJZvlQkMZju3RKw2zSaqRWt4kOLJqHLud+xrVis+rfMhJSafzBgR1cLKRM6ms47FZeM1g4ty1gjtWUUQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.38.0.tgz",
+      "integrity": "sha512-XkZhqeNscp/AX01YaA0eNwHfJpokgCoMzZpPB74ejfGHiCX6R2dJqKHJUNTNDLexQZp+E7crgRPVxmvoAkA3Vg==",
       "dependencies": {
-        "@cord-sdk/types": "1.37.1-canary.1"
+        "@cord-sdk/types": "1.38.0"
       }
     },
-    "node_modules/@cord-sdk/components/node_modules/@cord-sdk/types": {
-      "version": "1.37.1-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.37.1-canary.1.tgz",
-      "integrity": "sha512-9PG17oPPjaJkG5PrQaqV3GXbBq1uwFXR5hP2t7yMuVm377P8p2olshQCVQ596YVzzGBfMab+cTkEoMolsabRWQ=="
-    },
     "node_modules/@cord-sdk/react": {
-      "version": "1.37.1-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.37.1-canary.1.tgz",
-      "integrity": "sha512-i60YY4YiLis0m+vnqC/YuYjbNiRkn4Qdp/flcPAtZ4avnwdJPW47QtTOnNyUUs27nNsePXkL4HPiNC/eGJK2FQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.38.0.tgz",
+      "integrity": "sha512-4VLlAsG3ZF4AWx6D0PJCDiBwTX8ScnMpcCRUob4tbxsUgbKQPKsFP8uAC8ZfOtIrBDMaEH875TWBhc+6uIXl+g==",
       "dependencies": {
-        "@cord-sdk/components": "1.37.1-canary.1",
-        "@cord-sdk/types": "1.37.1-canary.1",
+        "@cord-sdk/components": "1.38.0",
+        "@cord-sdk/types": "1.38.0",
         "@floating-ui/react-dom": "^1.3.0",
         "@radix-ui/react-slot": "^1.0.1",
         "@vanilla-extract/css": "^1.13.0",
@@ -2083,11 +2078,6 @@
         "react-dom": ">=17.0.0"
       }
     },
-    "node_modules/@cord-sdk/react/node_modules/@cord-sdk/types": {
-      "version": "1.37.1-canary.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.37.1-canary.1.tgz",
-      "integrity": "sha512-9PG17oPPjaJkG5PrQaqV3GXbBq1uwFXR5hP2t7yMuVm377P8p2olshQCVQ596YVzzGBfMab+cTkEoMolsabRWQ=="
-    },
     "node_modules/@cord-sdk/server": {
       "version": "1.36.2",
       "resolved": "https://registry.npmjs.org/@cord-sdk/server/-/server-1.36.2.tgz",
@@ -2097,10 +2087,9 @@
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.36.2.tgz",
-      "integrity": "sha512-mt3azBVB+vTAyuq9FKVqCvgTfqmVimc2Bfe762PSL3p5AE/AP3Q0dXeiPql2ScmEZ8QxkPQoWSFGGKohUcN/Ag==",
-      "dev": true
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.38.0.tgz",
+      "integrity": "sha512-APon7vlzJYtIFjYHrzHuM7zbgwMYMRtfXG+HbEtzR2K3vCRv4vstS/+tnZodtmY1vz4xUU6/CfZ8j9mxg20EbQ=="
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.37.1-canary.1",
+    "@cord-sdk/react": "^1.38.0",
     "@cord-sdk/server": "^1.36.0",
     "@heroicons/react": "^2.0.18",
     "@slack/web-api": "^6.8.1",

--- a/src/client/components/ClackMessage.tsx
+++ b/src/client/components/ClackMessage.tsx
@@ -64,7 +64,6 @@ export function ClackMessage({
     >
       <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         <StyledExperimentalMessage
-          threadID={message.threadID}
           message={message}
           replace={replace}
           $hasReactions={(message.reactions?.length ?? 0) > 0}

--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -8,7 +8,7 @@ import type {
   CoreMessageData,
   ThreadSummary,
 } from '@cord-sdk/types';
-import type { MessageProps as ExperimentalMessageProps } from '@cord-sdk/react/dist/mjs/types/canary/message/Message';
+
 import type { ReplaceConfig } from '@cord-sdk/react/dist/mjs/types/experimental/components/replacements';
 import { useTranslation } from 'react-i18next';
 
@@ -103,7 +103,7 @@ const ClackThreadContext = React.createContext<{
   thread?: ClientThreadData;
 }>(INITIAL_CLACK_CONTEXT_VALUE);
 
-function MessageWithPaginationTrigger(props: ExperimentalMessageProps) {
+function MessageWithPaginationTrigger(props: experimental.MessageProps) {
   const { t } = useTranslation();
   const {
     numReplies = 0,


### PR DESCRIPTION
Summary:

Updating it to get the latest CSS for Cord 4.0 components.

Test plan:
Load Clack locally, looks much better now!