### PR TITLE
Don't fetch unread counts for muted channels

### DIFF
--- a/src/client/components/ChannelThreadCountFetcher.tsx
+++ b/src/client/components/ChannelThreadCountFetcher.tsx
@@ -7,11 +7,9 @@ import { thread } from '@cord-sdk/react';
 export function ChannelThreadCountFetcher({
   setHasUnread,
   channelID,
-  isMuted,
 }: {
   setHasUnread: React.Dispatch<React.SetStateAction<boolean>>;
   channelID: string;
-  isMuted: boolean;
 }) {
   const summary = thread.useThreadCounts({
     filter: {
@@ -22,7 +20,7 @@ export function ChannelThreadCountFetcher({
     },
   });
 
-  setHasUnread(!isMuted && !!summary?.new);
+  setHasUnread(!!summary?.new);
 
   return null;
 }

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -32,20 +32,16 @@ export function ChannelButton({
   isActive: boolean;
   icon: React.ReactNode;
 }) {
-  // Just show website-events as always unread. Lol.  Because we were having perf
-  // issues regarding subscriptions for its thread counts.
   const [hasUnread, setHasUnread] = useState<boolean>(
-    option.id === 'website-events',
+    option.id === 'website-events' ? !option.muted : false,
   );
 
   return (
     <>
-      {/* See comment above.... don't fetch thread counts for website-events */}
-      {option.id !== 'website-events' && (
+      {option.id !== 'website-events' && !option.muted && (
         <ChannelThreadCountFetcher
           setHasUnread={setHasUnread}
           channelID={option.id}
-          isMuted={option.muted}
         />
       )}
       <SidebarButton


### PR DESCRIPTION
The big busy channels are the ones likely to be muted, and we were
already forcing the unread state to "not unread" for muted channels
*after fetching the count anyway* -- because fetching conditionally is
slightly annoying but someone already did that for `website-events`. So
we can slightly simplify the logic, fix a bug where a muted
`website-events` still displayed as unread, and stop fetching counts for
muted channels, all in one.

Test Plan:
Muted channels still look the same, except `website-events` is no longer
bolded while muted. Bold on non-muted channels goes away once the
channel is read. Didn't specifically test not fetching the counts but
code looks correct and is straightforward adaptation of existing code.
