### PR TITLE
Bootstrap users/groups on first start

### DIFF
--- a/src/server/consts.ts
+++ b/src/server/consts.ts
@@ -6,4 +6,4 @@ export const CORD_API_URL = 'https://api.staging.cord.com/';
 export const CORD_APP_ID = process.env.CORD_APP_ID!;
 export const CORD_SIGNING_SECRET = process.env.CORD_SIGNING_SECRET!;
 export const EVERYONE_ORG_ID = 'clack_all';
-export const ORG_NAME = 'All Clack Users';
+export const EVERYONE_ORG_NAME = 'All Clack Users';

--- a/src/server/fetchCordRESTApi.ts
+++ b/src/server/fetchCordRESTApi.ts
@@ -8,7 +8,7 @@ import {
 export async function fetchCordRESTApi<T>(
   endpoint: string,
   method: 'GET' | 'PUT' | 'POST' | 'DELETE' = 'GET',
-  body?: string,
+  body?: string | object,
 ): Promise<T> {
   return await serverFetchCordRESTApi(`v1/${endpoint}`, {
     method,

--- a/src/server/handlers/getChannels.ts
+++ b/src/server/handlers/getChannels.ts
@@ -8,9 +8,20 @@ export async function handleGetChannels(req: Request, res: Response) {
 
   const { groups } = await fetchCordRESTApi<ServerGetUser>(`users/${user_id}`);
 
-  const mostChannels = (
-    await fetchCordRESTApi<ServerUserData>('users/all_channels_holder')
-  ).metadata as Record<string, string>;
+  let mostChannels: Record<string, string>;
+  try {
+    mostChannels = (
+      await fetchCordRESTApi<ServerUserData>('users/all_channels_holder')
+    ).metadata as Record<string, string>;
+  } catch (e: any) {
+    if (e instanceof Error && e.message.includes('user_not_found')) {
+      // Create the holder user
+      await fetchCordRESTApi('users/all_channels_holder', 'PUT');
+      mostChannels = {};
+    } else {
+      throw e;
+    }
+  }
 
   const availableChannels = Object.entries(mostChannels)
     .sort((a, b) => a[0].localeCompare(b[0]))

--- a/src/server/handlers/login.ts
+++ b/src/server/handlers/login.ts
@@ -10,6 +10,7 @@ import {
   CORD_APP_ID,
   CORD_SIGNING_SECRET,
   EVERYONE_ORG_ID,
+  EVERYONE_ORG_NAME,
 } from 'src/server/consts';
 
 const slackClient = new Slack.WebClient();
@@ -190,18 +191,17 @@ function redirectToSlackLogin(req: Request, res: Response) {
 }
 
 async function ensureMemberOfEveryoneOrg(userID: string) {
-  // Make sure the user exists. Their details are put into their token and get
-  // set that way, so we don't need to actually set any fields here (which lets
-  // us do this unconditionally since it won't overwrite anything).
-  await fetchCordRESTApi(`users/${userID}`, 'PUT');
-
-  // Adding a user who is already a member is explicitly documented as not an
-  // error, so we can do this unconditionally.
-  await fetchCordRESTApi(
-    `groups/${EVERYONE_ORG_ID}/members`,
-    'POST',
-    JSON.stringify({
-      add: [userID],
-    }),
-  );
+  // Ensure the group exists
+  await fetchCordRESTApi(`groups/${EVERYONE_ORG_ID}`, 'PUT', {
+    name: EVERYONE_ORG_NAME,
+  });
+  // Make sure the user exists and is a member of the everyone org. Their
+  // details are put into their token and get set that way, so we don't need to
+  // actually set any fields here (which lets us do this unconditionally since
+  // it won't overwrite anything).
+  await fetchCordRESTApi(`users/${userID}`, 'PUT', {
+    // Adding a user to a group they're already a member of is explicitly
+    // documented as not an error, so we can do this unconditionally.
+    addGroups: [EVERYONE_ORG_ID],
+  });
 }


### PR DESCRIPTION
For the first run experience, add a couple places where we add the
all_channels_holder user and clack_all group if they don't yet exist.
This makes it so you don't have to do anything specific on the Cord
side when running Clack for the first time, it just creates the helper
bits it needs if they're missing.

The clack_all group is created only in the login path, so it doesn't
work if you delete the group and then load the app, but that doesn't
seem super important to support.