### PR TITLE
Don't target cord-component, target cord-thread and cord-message

### DIFF
--- a/src/client/components/style/GlobalStyle.tsx
+++ b/src/client/components/style/GlobalStyle.tsx
@@ -52,7 +52,7 @@ export const GlobalStyle = createGlobalStyle`
     color: rgb(29,28,29);
   }
 
-  html .cord-component {
+  html .cord-thread, html .cord-message {
     /* This is very hard to override, Cord bug? */
     font-size: inherit;
   }


### PR DESCRIPTION
I noticed the seen by state looked too big, and it turned out to be
because Clack was targeting cord-component, which in the v2 components
is on a whole lot of things.  Target the top-level components we use
(cord-thread and cord-message) instead.

Before:

After: