### PR TITLE
Remove duplicate Channel definition

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -9,7 +9,7 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
 
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { useAPIFetch, useLazyAPIFetch } from 'src/client/hooks/useAPIFetch';
 import { Topbar as TopbarDefault } from 'src/client/components/Topbar';
 import { Chat } from 'src/client/components/Chat';

--- a/src/client/components/ChannelsRightClickMenu.tsx
+++ b/src/client/components/ChannelsRightClickMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { styled } from 'styled-components';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { ReactPortal } from 'src/client/components/ReactPortal';
 import { useMutedChannels } from 'src/client/hooks/useMutedChannels';
 

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 import { thread, user, betaV2 } from '@cord-sdk/react';
 import { HashtagIcon, LockClosedIcon } from '@heroicons/react/20/solid';
 import { useTranslation } from 'react-i18next';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { PinnedMessages } from 'src/client/components/PinnedMessages';
 import { Toolbar } from 'src/client/components/Toolbar';
 import { PushPinSvg } from 'src/client/components/svg/PushPinSVG';

--- a/src/client/components/PageUsersLabel.tsx
+++ b/src/client/components/PageUsersLabel.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from 'react-tooltip';
 import styled from 'styled-components';
 import { Facepile } from '@cord-sdk/react';
 import type { ClientUserData } from '@cord-sdk/types';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { combine } from 'src/client/utils';
 import { UsersInChannelModal } from 'src/client/components/UsersInChannelModal';

--- a/src/client/components/PinnedMessages.tsx
+++ b/src/client/components/PinnedMessages.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ThreadList } from '@cord-sdk/react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { Modal } from 'src/client/components/Modal';
 import { EVERYONE_ORG_ID } from 'src/client/consts/consts';

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { NotificationListLauncher } from '@cord-sdk/react';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { PageHeader } from 'src/client/components/PageHeader';
 import { Channels } from 'src/client/components/Channels';
 import { NotificationsRequestBanner } from 'src/client/components/NotificationsRequestBanner';

--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -12,7 +12,7 @@ import type {
 import { useTranslation } from 'react-i18next';
 
 import { CordVersionContext } from 'src/client/context/CordVersionContext';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { ClackSendButton } from 'src/client/components/ClackSendButton';
 import { PageHeader } from 'src/client/components/PageHeader';
 import { Colors } from 'src/client/consts/Colors';

--- a/src/client/components/Threads.tsx
+++ b/src/client/components/Threads.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { thread } from '@cord-sdk/react';
 import { styled } from 'styled-components';
 import { ArrowDownIcon, XMarkIcon } from '@heroicons/react/24/outline';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { PaginationTrigger } from 'src/client/components/PaginationTrigger';
 import { MessageListItem } from 'src/client/components/MessageListItem';
 import { EmptyChannel } from 'src/client/components/EmptyChannel';

--- a/src/client/components/UsersInChannelModal.tsx
+++ b/src/client/components/UsersInChannelModal.tsx
@@ -9,7 +9,7 @@ import {
 import { UserPlusIcon } from '@heroicons/react/24/outline';
 import { LockClosedIcon, HashtagIcon } from '@heroicons/react/24/solid';
 import type { ClientUserData } from '@cord-sdk/types';
-import type { Channel } from 'src/client/context/ChannelsContext';
+import type { Channel } from 'src/client/consts/Channel';
 import { Colors } from 'src/client/consts/Colors';
 import { ActiveBadge } from 'src/client/components/ActiveBadge';
 import { Name } from 'src/client/components/Name';

--- a/src/client/context/ChannelsContext.tsx
+++ b/src/client/context/ChannelsContext.tsx
@@ -1,8 +1,5 @@
 import { createContext } from 'react';
-export type Channel = {
-  id: string;
-  org: string;
-};
+import type { Channel } from 'src/client/consts/Channel';
 
 type ChannelsContextType = {
   channels: Channel[];


### PR DESCRIPTION
We had the `Channel` type defined identically in two places, just use
one.