### PR TITLE
Add display of direct messages

### DIFF
--- a/src/client/components/ChannelPicker.tsx
+++ b/src/client/components/ChannelPicker.tsx
@@ -79,17 +79,17 @@ export function ChannelPicker({
       const text = e.target.value.trim();
       setChannelText(text);
       const newFilteredChannels = channels
-        .filter((channel) => channel.id.includes(text))
+        .filter((channel) => channel.name.includes(text))
         .sort((a, b) => {
           // Sort exact matches to the top
-          if (a.id === text) {
+          if (a.name === text) {
             return -1;
           }
-          if (b.id === text) {
+          if (b.name === text) {
             return 1;
           }
           // Otherwise prefer things that match earlier in the channel id
-          return a.id.indexOf(text) - b.id.indexOf(text);
+          return a.name.indexOf(text) - b.name.indexOf(text);
         });
 
       setFilteredChannels(newFilteredChannels);
@@ -125,10 +125,10 @@ export function ChannelPicker({
           {filteredChannels.map((channel) =>
             channel.id === filteredChannels[selectedChannelIndex].id ? (
               <SelectedListItem key={channel.id} ref={selectedRef}>
-                #{channel.id}
+                #{channel.name}
               </SelectedListItem>
             ) : (
-              <ListItem key={channel.id}>#{channel.id}</ListItem>
+              <ListItem key={channel.id}>#{channel.name}</ListItem>
             ),
           )}
         </List>

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -1,7 +1,11 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { styled } from 'styled-components';
 import { thread, user, betaV2 } from '@cord-sdk/react';
-import { HashtagIcon, LockClosedIcon } from '@heroicons/react/20/solid';
+import {
+  ChatBubbleLeftRightIcon,
+  HashtagIcon,
+  LockClosedIcon,
+} from '@heroicons/react/20/solid';
 import { useTranslation } from 'react-i18next';
 import type { Channel } from 'src/client/consts/Channel';
 import { PinnedMessages } from 'src/client/components/PinnedMessages';
@@ -20,6 +24,7 @@ import type { ClackTheme } from 'src/client/consts/theme';
 import { Spring } from 'src/client/components/SpringFall';
 import { CordVersionContext } from 'src/client/context/CordVersionContext';
 import { ClackSendButton } from 'src/client/components/ClackSendButton';
+import { DM_CHANNEL_PREFIX } from 'src/common/consts';
 
 interface ChatProps {
   channel: Channel;
@@ -55,14 +60,19 @@ export function Chat({ channel, onOpenThread, clackTheme }: ChatProps) {
 
   const showToolbar = pinnedThreads.length > 0 && isAtBottomOfThreads;
 
-  const channelIcon =
-    channel.org === EVERYONE_ORG_ID ? <ChannelIcon /> : <PrivateChannelIcon />;
+  const channelIcon = channel.id.startsWith(DM_CHANNEL_PREFIX) ? (
+    <DirectMessageIcon />
+  ) : channel.org === EVERYONE_ORG_ID ? (
+    <ChannelIcon />
+  ) : (
+    <PrivateChannelIcon />
+  );
 
   const cordVersionContext = useContext(CordVersionContext);
 
   const createThreadOptions = useMemo(() => {
     return {
-      name: `#${channel.id}`,
+      name: `#${channel.name}`,
       location: { channel: channel.id },
       // This is not always the right url, but the navigate prop in
       // CordProvider makes sure that clicking on notifications takes
@@ -71,7 +81,7 @@ export function Chat({ channel, onOpenThread, clackTheme }: ChatProps) {
       url: window.location.href,
       groupID: channel.org,
     };
-  }, [channel.id, channel.org]);
+  }, [channel.id, channel.name, channel.org]);
 
   return (
     <Wrapper>
@@ -81,7 +91,7 @@ export function Chat({ channel, onOpenThread, clackTheme }: ChatProps) {
             {channel.org && (
               <>
                 {channelIcon}
-                {channel.id}
+                {channel.name}
               </>
             )}
           </ChannelDetailsHeader>
@@ -118,7 +128,7 @@ export function Chat({ channel, onOpenThread, clackTheme }: ChatProps) {
       {cordVersionContext.version === '3.0' ? (
         <StyledComposer
           location={{ channel: channel.id }}
-          threadName={`#${channel.id}`}
+          threadName={`#${channel.name}`}
           groupId={channel.org}
           showExpanded
         />
@@ -172,13 +182,19 @@ const StyledThreads = styled(Threads)`
   grid-area: threads;
 `;
 
-export const ChannelIcon = styled(HashtagIcon)`
+const ChannelIcon = styled(HashtagIcon)`
   margin-right: 4px;
   width: 16px;
   height: 16px;
 `;
 
-export const PrivateChannelIcon = styled(LockClosedIcon)`
+const PrivateChannelIcon = styled(LockClosedIcon)`
+  margin-right: 4px;
+  width: 16px;
+  height: 16px;
+`;
+
+const DirectMessageIcon = styled(ChatBubbleLeftRightIcon)`
   margin-right: 4px;
   width: 16px;
   height: 16px;

--- a/src/client/components/EmptyChannel.tsx
+++ b/src/client/components/EmptyChannel.tsx
@@ -1,34 +1,49 @@
 import React from 'react';
 import { css, styled } from 'styled-components';
-import { HashtagIcon, LockClosedIcon } from '@heroicons/react/20/solid';
+import {
+  ChatBubbleLeftRightIcon,
+  HashtagIcon,
+  LockClosedIcon,
+} from '@heroicons/react/20/solid';
 import type { Channel } from 'src/client/consts/Channel';
 import { EVERYONE_ORG_ID } from 'src/client/consts/consts';
+import { DM_CHANNEL_PREFIX } from 'src/common/consts';
 
 interface EmptyChannelProps {
   channel: Channel;
 }
 
 export function EmptyChannel({ channel }: EmptyChannelProps) {
-  const icon = (type: 'title' | 'text') =>
-    channel.org === EVERYONE_ORG_ID ? (
-      <ChannelIcon $type={type} />
-    ) : (
-      <PrivateChannelIcon $type={type} />
-    );
+  const icon = (type: 'title' | 'text') => {
+    if (channel.id.startsWith(DM_CHANNEL_PREFIX)) {
+      return <DirectMessageIcon $type={type} />;
+    } else if (channel.org === EVERYONE_ORG_ID) {
+      return <ChannelIcon $type={type} />;
+    } else {
+      return <PrivateChannelIcon $type={type} />;
+    }
+  };
   return (
     <Root>
       <ChannelName>
         {' '}
         {icon('title')}
-        {channel.id}
+        {channel.name}
       </ChannelName>
       <TextContainer>
-        <span>This is the very beginning of the </span>
+        <span>
+          This is the very beginning of{' '}
+          {channel.id.startsWith(DM_CHANNEL_PREFIX)
+            ? 'your direct message with'
+            : 'the'}{' '}
+        </span>
         <Emphasis>
           {icon('text')}
-          {channel.id}
+          {channel.name}
         </Emphasis>{' '}
-        <span> channel.</span>
+        <span>
+          {channel.id.startsWith(DM_CHANNEL_PREFIX) ? '' : ' channel'}.
+        </span>
       </TextContainer>
     </Root>
   );
@@ -60,6 +75,23 @@ const ChannelIcon = styled(HashtagIcon)<{ $type: 'title' | 'text' }>`
 `;
 
 const PrivateChannelIcon = styled(LockClosedIcon)<{ $type: 'title' | 'text' }>`
+  ${({ $type }) =>
+    $type === 'title'
+      ? css`
+          margin-right: 4px;
+          width: 32px;
+          height: 32px;
+        `
+      : css`
+          margin-right: 2px;
+          width: 15px;
+          height: 15px;
+        `}
+`;
+
+const DirectMessageIcon = styled(ChatBubbleLeftRightIcon)<{
+  $type: 'title' | 'text';
+}>`
   ${({ $type }) =>
     $type === 'title'
       ? css`

--- a/src/client/components/SidebarButton.tsx
+++ b/src/client/components/SidebarButton.tsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 import { Colors } from 'src/client/consts/Colors';
 
 export function SidebarButton({
-  option,
+  displayName,
   onClick,
   onContextMenu,
   isActive,
@@ -11,7 +11,7 @@ export function SidebarButton({
   hasUnread,
   icon,
 }: {
-  option: string;
+  displayName: string;
   onClick: () => void;
   onContextMenu?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   isActive: boolean;
@@ -28,7 +28,7 @@ export function SidebarButton({
       $hasUnread={hasUnread}
     >
       {icon}
-      <SidebarButtonName>{option}</SidebarButtonName>
+      <SidebarButtonName>{displayName}</SidebarButtonName>
     </SidebarButtonStyled>
   );
 }

--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -242,7 +242,7 @@ export function ThreadDetails({
     <ThreadDetailsWrapper className={className}>
       <ThreadDetailsHeader>
         <span style={{ gridArea: 'thread' }}>{t('thread_header')}</span>
-        <ChannelName># {channel.id}</ChannelName>
+        <ChannelName>#{channel.name}</ChannelName>
         <CloseButton onClick={onClose}>
           <StyledXMarkIcon />
         </CloseButton>

--- a/src/client/consts/Channel.ts
+++ b/src/client/consts/Channel.ts
@@ -1,4 +1,5 @@
 export type Channel = {
   id: string;
+  name: string;
   org: string;
 };

--- a/src/client/context/ChannelsContext.tsx
+++ b/src/client/context/ChannelsContext.tsx
@@ -1,5 +1,11 @@
-import { createContext } from 'react';
+import { user } from '@cord-sdk/react';
+import * as React from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useCallback, useEffect, useMemo } from 'react';
 import type { Channel } from 'src/client/consts/Channel';
+import { EVERYONE_ORG_ID } from 'src/client/consts/consts';
+import { useLazyAPIFetch } from 'src/client/hooks/useAPIFetch';
+import { DM_CHANNEL_PREFIX } from 'src/common/consts';
 
 type ChannelsContextType = {
   channels: Channel[];
@@ -10,3 +16,100 @@ export const ChannelsContext = createContext<ChannelsContextType>({
   channels: [],
   refetch: () => {},
 });
+
+type ChannelsProviderProps = PropsWithChildren<{
+  channelID: string;
+  setChannel: (channel: Channel) => void;
+}>;
+
+export function ChannelsProvider({
+  channelID,
+  setChannel,
+  children,
+}: ChannelsProviderProps) {
+  const { channels, refetch } = useChannels();
+  useEffect(() => {
+    setChannel(
+      channels.find((c) => c.id === channelID) ?? {
+        id: '',
+        name: '',
+        org: EVERYONE_ORG_ID,
+      },
+    );
+  }, [channelID, channels, setChannel]);
+  return (
+    <ChannelsContext.Provider value={{ channels, refetch }}>
+      {children}
+    </ChannelsContext.Provider>
+  );
+}
+
+function useChannels(): { channels: Channel[]; refetch: () => void } {
+  const [channelFetchResponse, setChannelFetchResponse] = React.useState<
+    Record<string, string>
+  >({});
+
+  const fetch = useLazyAPIFetch();
+
+  const fetchChannels = useCallback(
+    () =>
+      void fetch('/channels', 'GET')
+        .then((allChannelsToOrg: { string: string }) => {
+          if (allChannelsToOrg) {
+            setChannelFetchResponse(allChannelsToOrg);
+          }
+        })
+        .catch((e) => console.error(e)),
+    [fetch],
+  );
+
+  useEffect(() => {
+    fetchChannels();
+    // Refetch channels every 5 mins in case someone else added one
+    const int = setInterval(
+      () => {
+        void fetchChannels();
+      },
+      1000 * 60 * 5,
+    );
+
+    return () => clearInterval(int);
+  }, [fetchChannels]);
+
+  const userIDsToQuery = useMemo(() => {
+    const userIDs = new Set<string>();
+    for (const key in channelFetchResponse) {
+      if (key.startsWith(DM_CHANNEL_PREFIX)) {
+        key
+          .substring(DM_CHANNEL_PREFIX.length)
+          .split(',')
+          .forEach((userID) => userIDs.add(userID));
+      }
+    }
+    return [...userIDs];
+  }, [channelFetchResponse]);
+
+  const viewer = user.useViewerData();
+  const userData = user.useUserData(userIDsToQuery);
+
+  return useMemo(() => {
+    if (!viewer || !userIDsToQuery.every((userID) => userID in userData)) {
+      return { channels: [], refetch: fetchChannels };
+    }
+    const channels: Channel[] = [];
+    for (const key in channelFetchResponse) {
+      if (key.startsWith(DM_CHANNEL_PREFIX)) {
+        const name = key
+          .substring(DM_CHANNEL_PREFIX.length)
+          .split(',')
+          .filter((userID) => userID !== viewer.id)
+          .map((userID) => userData[userID]!.displayName)
+          .join(', ');
+        channels.push({ id: key, name, org: key });
+      } else {
+        channels.push({ id: key, name: key, org: channelFetchResponse[key] });
+      }
+    }
+    return { channels, refetch: fetchChannels };
+  }, [viewer, userIDsToQuery, fetchChannels, userData, channelFetchResponse]);
+}

--- a/src/common/consts.ts
+++ b/src/common/consts.ts
@@ -1,0 +1,1 @@
+export const DM_CHANNEL_PREFIX = 'dm:';

--- a/src/server/handlers/getChannels.ts
+++ b/src/server/handlers/getChannels.ts
@@ -1,5 +1,6 @@
 import type { ServerGetUser, ServerUserData } from '@cord-sdk/types';
 import type { Request, Response } from 'express';
+import { DM_CHANNEL_PREFIX } from 'src/common/consts';
 import { EVERYONE_ORG_ID } from 'src/server/consts';
 import { fetchCordRESTApi } from 'src/server/fetchCordRESTApi';
 
@@ -39,6 +40,12 @@ export async function handleGetChannels(req: Request, res: Response) {
   // Special channels: everyone gets these testing channels at the end of their list
   availableChannels['noise'] = EVERYONE_ORG_ID;
   availableChannels['what-the-quack'] = EVERYONE_ORG_ID;
+
+  groups
+    .filter((group) => group.toString().startsWith(DM_CHANNEL_PREFIX))
+    .forEach((group) => {
+      availableChannels[group.toString()] = group.toString();
+    });
 
   res.send(availableChannels);
 }


### PR DESCRIPTION
Add the ability to show direct message channels between an ad hoc
group of users.

The data model here is that direct message channels don't exist inside
`all_channels_holder`, but instead are based on being a member of a
group named `dm:USERID1,USERID2`.  The channel fetcher on the backend
finds all the groups the user is a member of that have the `dm:`
prefix and sends them to the client.  Then the client mostly just
treats those as channels like normal except for using a different
icon.

The main code change is to expand the `Channel` structure to include a
name separate from the ID, and then a chunk of code in the channels
provider to fetch the list of channels, look up the names of all the
users in all the DM channels, and set the names of the channels to the
appropriate things.

This doesn't yet include the ability to create a DM channel, so it
only works if you create these groups manually in the command line,
the Cord console, etc.  That will come in a future diff.

I'm also not super pleased with all the places that have to check for
`channel.id.startsWith(DM_CHANNEL_PREFIX)`.  I might add a separate
property in the `Channel` struct for that to make the code clearer in
a future diff.