### PR TITLE
Update line height for channel buttons

### DIFF
--- a/src/client/components/SidebarButton.tsx
+++ b/src/client/components/SidebarButton.tsx
@@ -51,7 +51,7 @@ const SidebarButtonStyled = styled.button<{
   padding: 0 10px 0 16px;
 
   font-size: 15px;
-  line-height: 28px;
+  line-height: 20px;
   min-height: 28px;
   font-weight: ${({ $hasUnread }) => ($hasUnread ? '900' : '400')};
 


### PR DESCRIPTION
When you have multiline channel buttons (like you can get when you
have a DM with multiple people in it), the lower line height looks
better.

Before:

<img width="250" alt="Screenshot 2024-05-01 at 2 50 09 PM" src="https://github.com/getcord/clack/assets/215991/15453021-f0ca-489a-bb36-0ed2e81fec81">

After:

<img width="251" alt="Screenshot 2024-05-01 at 2 49 55 PM" src="https://github.com/getcord/clack/assets/215991/aaf06ebd-f4b4-4f92-a931-dbf56937cd12">