### PR TITLE
Fix display of two list-of-users modals

### DIFF
--- a/src/client/components/AddDirectMessageModal.tsx
+++ b/src/client/components/AddDirectMessageModal.tsx
@@ -128,10 +128,11 @@ const Modal = styled(DefaultModal)`
 `;
 
 const Box = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
   backgroundColor: 'white',
   borderRadius: '12px',
   color: 'black',
-  gap: '12px',
   minWidth: '550px',
   maxHeight: '700px',
   minHeight: '500px',
@@ -141,6 +142,7 @@ const Box = styled.div({
 const Header = styled.div({
   display: 'flex',
   justifyContent: 'space-between',
+  alignItems: 'center',
   backgroundColor: 'transparent',
   padding: '24px 24px',
   borderBottom: `1px solid ${Colors.gray_light}`,
@@ -199,6 +201,7 @@ const Avatar = styled(DefaultAvatar)`
 const Heading = styled.h2({
   display: 'flex',
   marginTop: 0,
+  marginBottom: 0,
   alignItems: 'center',
 });
 

--- a/src/client/components/AddDirectMessageModal.tsx
+++ b/src/client/components/AddDirectMessageModal.tsx
@@ -200,8 +200,7 @@ const Avatar = styled(DefaultAvatar)`
 
 const Heading = styled.h2({
   display: 'flex',
-  marginTop: 0,
-  marginBottom: 0,
+  marginBlock: 0,
   alignItems: 'center',
 });
 

--- a/src/client/components/UsersInChannelModal.tsx
+++ b/src/client/components/UsersInChannelModal.tsx
@@ -338,10 +338,11 @@ const Modal = styled.div<{ $order: number }>(({ $order }) => ({
 }));
 
 const Box = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
   backgroundColor: 'white',
   borderRadius: '12px',
   color: 'black',
-  gap: '12px',
   minWidth: '550px',
   maxHeight: '700px',
   minHeight: '500px',
@@ -350,6 +351,7 @@ const Box = styled.div({
 const Header = styled.div({
   display: 'flex',
   justifyContent: 'space-between',
+  alignItems: 'center',
   backgroundColor: 'transparent',
   padding: '24px 24px',
   borderBottom: `1px solid ${Colors.gray_light}`,
@@ -358,6 +360,7 @@ const Header = styled.div({
 const Heading = styled.h2({
   display: 'flex',
   marginTop: 0,
+  marginBottom: 0,
 });
 
 const UsersList = styled.div({

--- a/src/client/components/UsersInChannelModal.tsx
+++ b/src/client/components/UsersInChannelModal.tsx
@@ -359,8 +359,7 @@ const Header = styled.div({
 
 const Heading = styled.h2({
   display: 'flex',
-  marginTop: 0,
-  marginBottom: 0,
+  marginBlock: 0,
 });
 
 const UsersList = styled.div({


### PR DESCRIPTION
These two modals (which are very similar, and maybe should be
combined) both had a problem where in some cases and in some display
sizes they looked weird.  The commit button could render outside the
bounds of the modal, the header text wasn't visually centered within
the header, and the close box was weirdly aligned with the rest of the
header.  Fix those things.