### PR TITLE
Fix style of deleted message and link previews

### DIFF
--- a/src/client/components/style/StyledCord.tsx
+++ b/src/client/components/style/StyledCord.tsx
@@ -145,7 +145,6 @@ export const StyledExperimentalMessage = styled(betaV2.Message)<{
   $hasReactions: boolean;
 }>`
   &.cord-message {
-    padding: 0;
     align-items: flex-start;
     background-color: inherit;
     padding: 8px 20px;
@@ -177,6 +176,11 @@ export const StyledExperimentalMessage = styled(betaV2.Message)<{
       max-height: 300px;
       max-width: 300px;
     }
+  }
+
+  &.cord-message.cord-deleted {
+    display: flex;
+    align-items: center;
   }
 
   .cord-avatar-container {
@@ -244,6 +248,11 @@ export const StyledExperimentalMessage = styled(betaV2.Message)<{
 
   .cord-message-options-buttons > button {
     display: none;
+  }
+
+  .cord-link-preview-image {
+    max-width: 300px;
+    max-height: 200px;
   }
 `;
 


### PR DESCRIPTION
## Summary
Fix styling of the deleted message and the link previews

## Test plan
<img width="348" alt="Screenshot 2024-05-03 at 10 11 43" src="https://github.com/getcord/clack/assets/102948032/ae0cfc30-c3ae-4465-937f-75048c6dfa9f">
<img width="786" alt="Screenshot 2024-05-03 at 10 11 33" src="https://github.com/getcord/clack/assets/102948032/c61ed02e-d069-4ca4-8920-f57b06abd466">
