### PR TITLE
Fix updating a component from inside another error

### DIFF
--- a/src/client/components/ChannelThreadCountFetcher.tsx
+++ b/src/client/components/ChannelThreadCountFetcher.tsx
@@ -1,4 +1,5 @@
 import { thread } from '@cord-sdk/react';
+import { useEffect } from 'react';
 
 /**
  * Just a hack so that we can conditionally call a hook that was in Channels.tsx
@@ -20,7 +21,10 @@ export function ChannelThreadCountFetcher({
     },
   });
 
-  setHasUnread(!!summary?.new);
+  const hasUnread = !!summary?.new;
+  useEffect(() => {
+    setHasUnread(hasUnread);
+  }, [hasUnread, setHasUnread]);
 
   return null;
 }


### PR DESCRIPTION
Apparently you can't call a `setState` from one component inside the
render of another, which was the entire point of this component. Not
sure what the "right" fix is, but for our purposes throwing this into a
`useEffect` is totally fine (do not care about the extra render cycle
latency) and silences the error.

Test Plan: Load Clack, no more spew in dev tools console about this.
