### PR TITLE
Add separate threadName channel property

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -56,6 +56,7 @@ export function App() {
   const [channel, setChannel] = useState<Channel>({
     id: '',
     name: '',
+    threadName: '',
     org: EVERYONE_ORG_ID,
   });
   // We only hide the sidebar on mobile, to regain some space.

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -75,7 +75,7 @@ export function Chat({ channel, onOpenThread, clackTheme }: ChatProps) {
 
   const createThreadOptions = useMemo(() => {
     return {
-      name: `${isDirectMessageChannel(channel.id) ? '' : '#'}${channel.name}`,
+      name: channel.threadName,
       location: { channel: channel.id },
       // This is not always the right url, but the navigate prop in
       // CordProvider makes sure that clicking on notifications takes
@@ -87,7 +87,7 @@ export function Chat({ channel, onOpenThread, clackTheme }: ChatProps) {
         addSubscribers: extractUsersFromDirectMessageChannel(channel.id),
       }),
     };
-  }, [channel.id, channel.name, channel.org]);
+  }, [channel.id, channel.threadName, channel.org]);
 
   return (
     <Wrapper>
@@ -134,7 +134,7 @@ export function Chat({ channel, onOpenThread, clackTheme }: ChatProps) {
       {cordVersionContext.version === '3.0' ? (
         <StyledComposer
           location={{ channel: channel.id }}
-          threadName={`#${channel.name}`}
+          threadName={channel.threadName}
           groupId={channel.org}
           showExpanded
         />

--- a/src/client/consts/Channel.ts
+++ b/src/client/consts/Channel.ts
@@ -1,5 +1,6 @@
 export type Channel = {
   id: string;
   name: string;
+  threadName: string;
   org: string;
 };

--- a/src/client/context/ChannelsContext.tsx
+++ b/src/client/context/ChannelsContext.tsx
@@ -36,6 +36,7 @@ export function ChannelsProvider({
       channels.find((c) => c.id === channelID) ?? {
         id: '',
         name: '',
+        threadName: '',
         org: EVERYONE_ORG_ID,
       },
     );
@@ -105,9 +106,17 @@ function useChannels(): { channels: Channel[]; refetch: () => void } {
           .filter((userID) => userID !== viewer.id)
           .map((userID) => userData[userID]!.displayName)
           .join(', ');
-        channels.push({ id: key, name, org: key });
+        const threadName = extractUsersFromDirectMessageChannel(key)
+          .map((userID) => userData[userID]!.displayName)
+          .join(', ');
+        channels.push({ id: key, name, threadName, org: key });
       } else {
-        channels.push({ id: key, name: key, org: channelFetchResponse[key] });
+        channels.push({
+          id: key,
+          name: key,
+          threadName: `#${key}`,
+          org: channelFetchResponse[key],
+        });
       }
     }
     return { channels, refetch: fetchChannels };


### PR DESCRIPTION
The display name of a DM channel (the `name` property) omits the
user's name, since all DMs the user can use must have them in it, so
it's just noise.  However, the name of the thread is frequently shown
to other people, such as in email notifications of new messages, and
omitting the viewer means that if Person A sends a DM to Person B,
then Person B will get an email notification with a title such as "New
activity on Person B", which doesn't make sense.

Instead, ship around a separate `threadName` property that does
include the user's name and we use as the thread name, so that it will
say "New activity on Person A, Person B", which looks much more
correct for a DM.