### PR TITLE
Update styling for deleted, action messages

### DIFF
--- a/src/client/components/style/StyledCord.tsx
+++ b/src/client/components/style/StyledCord.tsx
@@ -144,7 +144,7 @@ export const StyledExperimentalMessage = styled(betaV2.Message)<{
   $hasReplies: boolean;
   $hasReactions: boolean;
 }>`
-  &.cord-message {
+  &.cord-message:not(.cord-deleted, .cord-action) {
     align-items: flex-start;
     background-color: inherit;
     padding: 8px 20px;
@@ -176,11 +176,6 @@ export const StyledExperimentalMessage = styled(betaV2.Message)<{
       max-height: 300px;
       max-width: 300px;
     }
-  }
-
-  &.cord-message.cord-deleted {
-    display: flex;
-    align-items: center;
   }
 
   .cord-avatar-container {


### PR DESCRIPTION
PR #161 fixed styling for deleted messages by making them
display:flex, but the Cord CSS uses grid and that means we basically
stomp all over the default styling.  Instead, just apply our custom
grid message layout if it's not a deleted or action message, which
means other things use the default styling.