### PR TITLE
Stop using placeholder channel

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -53,12 +53,7 @@ export function App() {
   const { t } = useTranslation();
   const [cordToken, cordUserID] = useCordToken();
   const { channelID: channelIDParam, threadID } = useParams();
-  const [channel, setChannel] = useState<Channel>({
-    id: '',
-    name: '',
-    threadName: '',
-    org: EVERYONE_ORG_ID,
-  });
+  const [channel, setChannel] = useState<Channel | undefined>();
   // We only hide the sidebar on mobile, to regain some space.
   const [showSidebar, setShowSidebar] = React.useState(false);
   const [lang, setLang] = useStateWithLocalStoragePersistence<Language>(
@@ -77,7 +72,9 @@ export function App() {
   const channelID = channelIDParam ?? 'general';
 
   const onOpenThread = (threadID: string) => {
-    navigate(`/channel/${channel.id}/thread/${threadID}`);
+    if (channel) {
+      navigate(`/channel/${channel.id}/thread/${threadID}`);
+    }
   };
 
   const onCordNavigate: NavigateFn = React.useCallback(
@@ -93,8 +90,8 @@ export function App() {
   );
 
   const translations = useMemo(
-    () => getCordTranslations(channel.name),
-    [channel.name],
+    () => getCordTranslations(channel?.name ?? ''),
+    [channel?.name],
   );
 
   const beforeMessageCreate = useCallback(
@@ -127,8 +124,11 @@ export function App() {
       <GlobalStyle />
       <Helmet>
         <title>
-          {isDirectMessageChannel(channel.id) ? '' : '#'}
-          {channel.name} - {t('name')}
+          {channel
+            ? `${isDirectMessageChannel(channel.id) ? '' : '#'}${
+                channel.name
+              } - ${t('name')}`
+            : t('name')}
         </title>
       </Helmet>
       <CordProvider
@@ -170,7 +170,7 @@ export function App() {
                   />
                   <MessageProvider>
                     <ResponsiveContent>
-                      {openPanel === 'channel' && channel.org && (
+                      {openPanel === 'channel' && channel && (
                         <Chat
                           key={channel.id}
                           channel={channel}
@@ -179,7 +179,7 @@ export function App() {
                         />
                       )}
                     </ResponsiveContent>
-                    {threadID && (
+                    {channel && threadID && (
                       <ThreadDetails
                         channel={channel}
                         threadID={threadID}

--- a/src/client/components/Channels.tsx
+++ b/src/client/components/Channels.tsx
@@ -86,7 +86,7 @@ export function Channels({
   currentChannel,
 }: {
   setCurrentChannelID: (channel: string) => void;
-  currentChannel: Channel;
+  currentChannel: Channel | undefined;
 }) {
   const { t } = useTranslation();
   const { channels: unsortedChannels } = useContext(ChannelsContext);
@@ -139,7 +139,7 @@ export function Channels({
       <ChannelsList>
         {channels.map((channel) => (
           <ChannelButton
-            isActive={currentChannel.id === channel.id}
+            isActive={currentChannel?.id === channel.id}
             key={channel.id}
             onClick={() => setCurrentChannelID(channel.id)}
             onContextMenu={(e: React.MouseEvent<HTMLButtonElement>) =>
@@ -173,7 +173,7 @@ export function Channels({
             onContextMenu={(e: React.MouseEvent<HTMLButtonElement>) =>
               onContextMenu(e, dm)
             }
-            isActive={currentChannel.id === dm.id}
+            isActive={currentChannel?.id === dm.id}
           />
         ))}
         <AddChannelsButton onClick={() => setAddDirectMessageModalOpen(true)}>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -13,7 +13,7 @@ import { themeOptions, type ClackTheme } from 'src/client/consts/theme';
 
 type SidebarProps = {
   className?: string;
-  channel: Channel;
+  channel: Channel | undefined;
   setShowSidebar?: React.Dispatch<React.SetStateAction<boolean>>;
   lang: Language;
   setLang: React.Dispatch<React.SetStateAction<Language>>;

--- a/src/client/context/ChannelsContext.tsx
+++ b/src/client/context/ChannelsContext.tsx
@@ -4,7 +4,6 @@ import type { PropsWithChildren } from 'react';
 import { createContext, useCallback, useEffect, useMemo } from 'react';
 import type { Channel } from 'src/client/consts/Channel';
 import {
-  EVERYONE_ORG_ID,
   isDirectMessageChannel,
   extractUsersFromDirectMessageChannel,
 } from 'src/common/consts';
@@ -22,7 +21,7 @@ export const ChannelsContext = createContext<ChannelsContextType>({
 
 type ChannelsProviderProps = PropsWithChildren<{
   channelID: string;
-  setChannel: (channel: Channel) => void;
+  setChannel: (channel: Channel | undefined) => void;
 }>;
 
 export function ChannelsProvider({
@@ -32,14 +31,7 @@ export function ChannelsProvider({
 }: ChannelsProviderProps) {
   const { channels, refetch } = useChannels();
   useEffect(() => {
-    setChannel(
-      channels.find((c) => c.id === channelID) ?? {
-        id: '',
-        name: '',
-        threadName: '',
-        org: EVERYONE_ORG_ID,
-      },
-    );
+    setChannel(channels.find((c) => c.id === channelID));
   }, [channelID, channels, setChannel]);
   return (
     <ChannelsContext.Provider value={{ channels, refetch }}>


### PR DESCRIPTION
Instead of generating a placeholder channel when someone links to
something that doesn't exist, use an explicit `undefined` value and
don't render a Chat component.  The Chat component that got rendered
for a placeholder channel worked, but it sent the messages off into
the ether, which is weird.  Instead, rendering nothing shows something
has gone wrong and you need to pick a channel that exists.