### PR TITLE
Update editing message styling and avatar

### DIFF
--- a/src/client/components/ClackMessage.tsx
+++ b/src/client/components/ClackMessage.tsx
@@ -158,6 +158,7 @@ const StyledAvatar = styled(betaV2.Avatar.ByID)`
   && {
     width: 36px;
     height: 36px;
+    flex-shrink: 0;
   }
 `;
 

--- a/src/client/components/style/StyledCord.tsx
+++ b/src/client/components/style/StyledCord.tsx
@@ -144,7 +144,7 @@ export const StyledExperimentalMessage = styled(betaV2.Message)<{
   $hasReplies: boolean;
   $hasReactions: boolean;
 }>`
-  &.cord-message:not(.cord-deleted, .cord-action) {
+  &.cord-message:not(.cord-deleted, .cord-action, .cord-composer) {
     align-items: flex-start;
     background-color: inherit;
     padding: 8px 20px;
@@ -176,6 +176,10 @@ export const StyledExperimentalMessage = styled(betaV2.Message)<{
       max-height: 300px;
       max-width: 300px;
     }
+  }
+
+  &.cord-message.cord-composer {
+    flex-shrink: 1;
   }
 
   .cord-avatar-container {


### PR DESCRIPTION
Summary:
Fix the styling for message in edit mode.

Make editing message shrink to not overflow and
avatar container to not shrink to keep it in
proportion.

Test plan:
Ran locally and saw new changes.

