### PR TITLE
Fix styling of ClackThreadV4

### DIFF
--- a/src/client/components/ThreadDetails.tsx
+++ b/src/client/components/ThreadDetails.tsx
@@ -330,16 +330,17 @@ const SeparatorLine = styled.hr`
 `;
 
 const StyledThreadByID = styled(betaV2.Thread.ByID)`
-  &.cord-component {
+  &.cord-v2 {
     border: none;
     height: 100%;
   }
-  &.cord-component .cord-composer {
+  & .cord-composer {
     margin: 0 20px 20px;
   }
-  &.cord-component .cord-thread-header-container {
+  & .cord-thread-header-container {
     display: none;
   }
-  &.cord-component .cord-scroll-container {
+  & .cord-scroll-container {
+    gap: 0;
   }
 `;


### PR DESCRIPTION
- We don't seem to insert `.cord-component` any more, so we should
  target something else (or nothing)
- The v4 scroll container inserts gaps but we insert our own padding in
  Clack, so we should remove the gaps to avoid double-padding

Test Plan: Load Clack, expand a thread, it looks better now.
