### PR TITLE
Add a build step to the smoke tests

### DIFF
--- a/.github/workflows/smoke-test-pullrequest.yml
+++ b/.github/workflows/smoke-test-pullrequest.yml
@@ -21,6 +21,12 @@ jobs:
         shell: bash
         run: npm ci
 
+      - name: 'Build'
+        shell: bash
+        run: |
+          npm run build-client
+          npm run build-server
+
       - name: 'Check TypeScript'
         shell: bash
         run: npm run tsc-once


### PR DESCRIPTION
Try to catch build breaks like we just had.

Test Plan:
This PR should fail until rebased on an update to a newer sdk version.
