### PR TITLE
Fix prod.sh copying static files

### DIFF
--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -6,8 +6,8 @@ set -x
 npm run build-server
 npm run build-client
 
-cp -r ./src/client/static ./dist/client/static
-cp -r ./src/client/index.html ./dist/client/index.html
+cp -r ./src/client/static ./dist/client
+cp ./src/client/index.html ./dist/client/index.html
 
 sudo cp -r /home/ec2-user/clack/dist/client /var/www/clack
 


### PR DESCRIPTION
This is fine the first time it's run, but subsequent times copy things
into `dist/client/static/static` which isn't what we want (and prevents
the new image in #172 from getting picked up). This is because the
directory already exists. So just copy into a directory we know already
exists (because `build-client` will create it).

Remove an extra `-r` from one line while I'm here.

This doesn't clean up deleted files, but that's less of a big deal.

Test Plan:
Create some temp directories and simulate the copies, and iterate. The
right thing happens.
