### PR TITLE
Fix tooltip not showing when hovering the menus

### DIFF
--- a/src/client/components/MoreActionsButton.tsx
+++ b/src/client/components/MoreActionsButton.tsx
@@ -141,7 +141,7 @@ export function MoreActionsButton({
       >
         <OptionsButton
           ref={moreOptionsButtonRef}
-          data-tooltip-id="more-actions-button"
+          data-tooltip-id="options-menu-tooltip"
           data-tooltip-content="More actions"
           data-tooltip-place="top"
           onClick={onMoreOptionsClick}

--- a/src/client/components/Options.tsx
+++ b/src/client/components/Options.tsx
@@ -10,6 +10,8 @@ import { MoreActionsButton } from 'src/client/components/MoreActionsButton';
 export const OPTIONS_ICON_HEIGHT = 20;
 export const OPTIONS_ICON_WIDTH = 20;
 
+export const OPTIONS_Z_INDEX = 1;
+
 interface OptionsProps {
   thread: ThreadSummary;
   hovered: boolean;
@@ -41,7 +43,7 @@ export function Options({
     (hovered || optionsHovered || showOptionsDialog) && (
       <OptionsStyled onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         <div
-          data-tooltip-id="reactions-button"
+          data-tooltip-id="options-menu-tooltip"
           data-tooltip-content="Find another reaction"
           data-tooltip-place="top"
         >
@@ -50,7 +52,7 @@ export function Options({
         {onOpenThread && (
           <OptionsButton
             onClick={() => onOpenThread(thread.id)}
-            data-tooltip-id="options-button"
+            data-tooltip-id="options-menu-tooltip"
             data-tooltip-content="Reply in thread"
             data-tooltip-place="top"
           >
@@ -103,7 +105,7 @@ const OptionsStyled = styled.div`
     box-shadow: inset 0 0 0 1.15px ${Colors.gray_light};
     border-radius: 8px;
     padding: 4px;
-    z-index: 1;
+    z-index: ${OPTIONS_Z_INDEX};
   }
 
   .cord-reaction-list .cord-pill {
@@ -136,11 +138,9 @@ export const OptionsButton = styled.div`
 
 // TODO could use WithTooltip
 export function OptionsMenuTooltips() {
-  return (
-    <>
-      <Tooltip id="reactions-button" />
-      <Tooltip id="options-button" />
-      <Tooltip id="more-actions-button" />
-    </>
-  );
+  return <StyledTooltip id="options-menu-tooltip" />;
 }
+
+const StyledTooltip = styled(Tooltip)`
+  z-index: ${OPTIONS_Z_INDEX + 1};
+`;


### PR DESCRIPTION
There's an issue with the z-index of the tooltips, so they're not showing when hovering the menus. Now they should show.

Also, it doesn't really make sense to have 3 different tooltips for the different buttons, we can use the same one. That way we also avoid problems of one still showing while another one is shown, because we'll reuse the only one when hovering new buttons.
