### PR TITLE
Fix date pills in Clack

### DIFF
--- a/src/client/components/ClackMessage.tsx
+++ b/src/client/components/ClackMessage.tsx
@@ -42,7 +42,7 @@ export function Message({ message, className }: betaV2.MessageProps) {
   return (
     <div>
       {lastMessageTimestamp && isDifferentDay ? (
-        <DateDivider timestamp={lastMessageTimestamp} />
+        <DateDivider timestamp={message.createdTimestamp} />
       ) : null}
       <ClackMessage
         message={message}


### PR DESCRIPTION
Noticed the date pills were off by the last message
that was sent.

Test Plan: Ran locally and can see correct date for messages.
