### PR TITLE
Remove Inline Thread borders

### DIFF
--- a/src/client/components/Threads.tsx
+++ b/src/client/components/Threads.tsx
@@ -295,6 +295,9 @@ const StyledExperimentalThreads = styled(experimental.Threads)({
     padding: 0,
     justifyContent: 'space-between',
   },
+  '& .cord-inline-thread': {
+    border: 'none',
+  },
   '& .cord-inline-reply-button': { display: 'none' },
   '& :not(.cord-message).cord-composer': { margin: '0 20px 20px 20px' },
 });


### PR DESCRIPTION
Summary:
Latest changes to Threads introduces default
borders on inline threads which breaks current
styling so update CSS to remove this once
clack updates.