### PR TITLE
Update SDK to 1.46.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cord-sdk/react": "^1.46.1",
+        "@cord-sdk/react": "^1.46.2",
         "@cord-sdk/server": "^1.46.1",
         "@giphy/js-fetch-api": "^5.5.0",
         "@giphy/react-components": "^9.5.0",
@@ -2037,20 +2037,20 @@
       }
     },
     "node_modules/@cord-sdk/components": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.46.1.tgz",
-      "integrity": "sha512-fGpT3iZzpCf+9F5LROiLxDwLJ6N+6VS2q2zv6TG7S21/X0LFdT/3QSbMGBolqLL4lsNSIkCRCdzqrc1gbhx/WQ==",
+      "version": "1.46.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/components/-/components-1.46.2.tgz",
+      "integrity": "sha512-506plaoYAjV11o4vh3KyfxCqDP+7iHxKYbFGS6KeckzmGL5dvsfltF/k7Y5dYkkvxaRymEj0Mpynu2klZt9Okg==",
       "dependencies": {
-        "@cord-sdk/types": "1.46.1"
+        "@cord-sdk/types": "1.46.2"
       }
     },
     "node_modules/@cord-sdk/react": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.46.1.tgz",
-      "integrity": "sha512-//uYDnbIwOF1CZP4BIqykbzMCi0qP8ieNkoomVm42z8YKu3TxXGW2nUR1DC36VW0q0CpEdDKhcVxLvz6fI+3+Q==",
+      "version": "1.46.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/react/-/react-1.46.2.tgz",
+      "integrity": "sha512-O0Krif1GMHrXlS+UdNK3v0Q+bUlKkcFOtz2YpmAtcxEKorR10Wc7Gj98w3XmXtPqT51Vtge2c+FvgUaMjX/SlA==",
       "dependencies": {
-        "@cord-sdk/components": "1.46.1",
-        "@cord-sdk/types": "1.46.1",
+        "@cord-sdk/components": "1.46.2",
+        "@cord-sdk/types": "1.46.2",
         "@floating-ui/react-dom": "^1.3.0",
         "@phosphor-icons/react": "^2.0.15",
         "@radix-ui/react-slot": "^1.0.1",
@@ -2090,9 +2090,9 @@
       }
     },
     "node_modules/@cord-sdk/types": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.46.1.tgz",
-      "integrity": "sha512-8qIqzrxIpk1PMgBP7XIdpGHYEYfStOas/cWdjZDe2we5AomHzpO7RMMpC3EPy9qcZcN19x9+wR5nwfBL4kwwZg=="
+      "version": "1.46.2",
+      "resolved": "https://registry.npmjs.org/@cord-sdk/types/-/types-1.46.2.tgz",
+      "integrity": "sha512-qZm2zIkpZHrj01RKTek0udxBP0PddxDkGXvp03S+iB4W+BsuXGyPL3mpAwEIpBdu3AKXMLuqupY63EJqVJg4jg=="
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@cord-sdk/react": "^1.46.1",
+    "@cord-sdk/react": "^1.46.2",
     "@cord-sdk/server": "^1.46.1",
     "@giphy/js-fetch-api": "^5.5.0",
     "@giphy/react-components": "^9.5.0",


### PR DESCRIPTION
Summary:

Updating to 1.46.2 to fix scroll container bug.

Test plan:
Load clack locally. Works much better! (No extra re-render that throws away the entire DOM)