### PR TITLE
Show pinned threads when scrolling to bottom

### DIFF
--- a/src/client/components/Threads.tsx
+++ b/src/client/components/Threads.tsx
@@ -244,7 +244,12 @@ const REPLACE = {
   ToolbarLayout: ToolbarLayoutWithGiphyButton,
 };
 
-function Threads4({ channel, onOpenThread }: ThreadsProps) {
+function Threads4({
+  channel,
+  onOpenThread,
+  onScrollToBottom,
+  onScrollUp,
+}: ThreadsProps) {
   const threadsData = thread.useThreads({
     filter: { location: { channel: channel.id } },
     sortDirection: 'descending',
@@ -297,6 +302,14 @@ function Threads4({ channel, onOpenThread }: ThreadsProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const [onBottom, setOnBottom] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (onBottom) {
+      onScrollToBottom();
+    } else {
+      onScrollUp();
+    }
+  }, [onBottom, onScrollToBottom, onScrollUp]);
 
   return (
     <ThreadsContext.Provider


### PR DESCRIPTION
## Summary

I forgot to wire the scroll listeners in Chat to the scroll listeners in Threads4, so that the pinned messages bar is shown when the threads are scrolled to the bottom. 